### PR TITLE
Add conveniences for OptiMimi

### DIFF
--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -195,12 +195,12 @@ end
 """
 Add a component to a model.
 """
-function addcomponent(m::Model, t, name::Symbol=:nothing; before=nothing,after=nothing)
+function addcomponent(m::Model, t, name::Union{Symbol,Void}=nothing; before=nothing,after=nothing)
     if before!=nothing && after!=nothing
         error("Can only specify before or after parameter")
     end
 
-    if name == :nothing
+    if name == nothing
         name = symbol(string(t))
     end
 

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -192,9 +192,16 @@ function setindex{T}(m::Model, name::Symbol, values::Vector{T})
     nothing
 end
 
-function addcomponent(m::Model, t, name::Symbol;before=nothing,after=nothing)
+"""
+Add a component to a model.
+"""
+function addcomponent(m::Model, t, name::Symbol=:nothing; before=nothing,after=nothing)
     if before!=nothing && after!=nothing
         error("Can only specify before or after parameter")
+    end
+
+    if name == :nothing
+        name = symbol(string(t))
     end
 
     comp = t(m.numberType, m.indices_counts)
@@ -216,15 +223,6 @@ function addcomponent(m::Model, t, name::Symbol;before=nothing,after=nothing)
 
     ComponentReference(m, name)
 end
-
-function addcomponent(m::Model, t;before=nothing,after=nothing)
-    addcomponent(m,t,symbol(string(t)),before=before,after=after)
-end
-
-"""
-Add a component to a model.
-"""
-addcomponent
 
 """
 Set the parameter of a component in a model to a given value.
@@ -269,6 +267,11 @@ function addparameter(m::Model, name::Symbol, value)
             p = UncertainArrayParameter(value)
             m.parameters[symbol(lowercase(string(name)))] = p
         else
+            if !(typeof(value) <: Array{m.numberType})
+                # E.g., if model takes Number and given Float64, convert it
+                value = convert(Array{m.numberType}, value)
+            end
+
             p = CertainArrayParameter(value)
             m.parameters[symbol(lowercase(string(name)))] = p
         end

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -195,13 +195,9 @@ end
 """
 Add a component to a model.
 """
-function addcomponent(m::Model, t, name::Union{Symbol,Void}=nothing; before=nothing,after=nothing)
+function addcomponent(m::Model, t, name::Symbol=Symbol(string(t)); before=nothing,after=nothing)
     if before!=nothing && after!=nothing
         error("Can only specify before or after parameter")
-    end
-
-    if name == nothing
-        name = symbol(string(t))
     end
 
     comp = t(m.numberType, m.indices_counts)


### PR DESCRIPTION
Both of these should make no difference for normal usage, but make things more convenient for a couple of use cases.  There are two changes:

* Combined the two `addcomponent` calls.  The only advantage for this is if you have another function which is calling `addcomponent` which could take a `name` parameter, and then can just pass it in.
* If the model uses a type other than `Float64`, it automatically does conversions.  So you can always call `setparameter` the same way, no matter what the number type of the model is.