### PR TITLE
Skip model dependencies except on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,13 @@ branches:
   only:
   - master
   - /release-.*/
+before_install:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
- - julia -e 'Pkg.clone(pwd())'
- - julia -e 'Pkg.build("Mimi")'
- - julia --check-bounds=yes -e 'Pkg.test("Mimi", coverage=true)'
- - julia test/test_dependencies.jl
+  - julia -e 'Pkg.clone(pwd())'
+  - julia -e 'Pkg.build("Mimi")'
+  - julia --check-bounds=yes -e 'Pkg.test("Mimi", coverage=true)'
+  - julia test/test_dependencies.jl
 after_success:
   - julia -e 'cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ branches:
   only:
   - master
   - /release-.*/
+script:
+ - julia -e 'Pkg.clone(pwd())'
+ - julia -e 'Pkg.build("$name")'
+ - if [ -f test/runtests.jl ]; then julia --check-bounds=yes -e 'Pkg.test("$name", coverage=true)'; fi
+ - julia test/test_dependencies.jl
 after_success:
   - julia -e 'cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ branches:
   - /release-.*/
 script:
  - julia -e 'Pkg.clone(pwd())'
- - julia -e 'Pkg.build("$name")'
- - if [ -f test/runtests.jl ]; then julia --check-bounds=yes -e 'Pkg.test("$name", coverage=true)'; fi
+ - julia -e 'Pkg.build("Mimi")'
+ - julia --check-bounds=yes -e 'Pkg.test("Mimi", coverage=true)'
  - julia test/test_dependencies.jl
 after_success:
   - julia -e 'cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -273,11 +273,7 @@ function connectparameter(m::Model, component::Symbol, name::Symbol, parameterna
     if isa(p, CertainScalarParameter) || isa(p, UncertainScalarParameter)
         push!(p.dependentCompsAndParams, (c, name))
     else
-        try
-            setfield!(c.Parameters,name,p.values)
-        catch
-            error("Failed to setfield for $name with setted size $(size(p.values)).")
-        end
+        setfield!(c.Parameters,name,p.values)
     end
     push!(m.parameters_that_are_set, string(component) * string(name))
 

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -249,7 +249,11 @@ function connectparameter(m::Model, component::Symbol, name::Symbol, parameterna
     if isa(p, CertainScalarParameter) || isa(p, UncertainScalarParameter)
         push!(p.dependentCompsAndParams, (c, name))
     else
-        setfield!(c.Parameters,name,p.values)
+        try
+            setfield!(c.Parameters,name,p.values)
+        catch
+            error("Failed to setfield for $name with setted size $(size(p.values)).")
+        end
     end
     push!(m.parameters_that_are_set, string(component) * string(name))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Mimi
 using Base.Test
 
-tests = ["main", "references", "units", "dependencies", "model_structure"]
+tests = ["main", "references", "units", "model_structure"]
 
 for t in tests
     fp = joinpath("test_$t.jl")

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -1,3 +1,7 @@
+if Pkg.installed("ZipFile") == nothing
+    Pkg.add("ZipFile")
+end
+
 using Mimi
 using ZipFile
 using Compat


### PR DESCRIPTION
Removed the test_dependencies.jl test from runtests, but added it to the travis script.

Note that I cleaned out the `if [ -f test/runtests.jl ]; then` part of the travis script.  If runtests.jl isn't there, that's a pretty big problem too.