### PR TITLE
Fix bug that surfaced in setleftoverparameters

### DIFF
--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -388,7 +388,7 @@ end
 function get_parameters(m::Model, component::ComponentInstanceInfo)
     _dict = Mimi.metainfo.getallcomps()
     _module = module_name(component.component_type.name.module)
-    _metacomponent = _dict[(_module, component.name)]
+    _metacomponent = _dict[(_module, component.component_type.name.name)]
     return keys(_metacomponent.parameters)
 end
 


### PR DESCRIPTION
Instance names of components in a model can never be resolved in the global meta component namespace, this looks things up with the component type name instead, which is the right case.

@ckingdon95 does my PR here look right to you? We should also add a test that catches this error.