### PR TITLE
collect() :time indices in tutorial

### DIFF
--- a/examples/tutorial/01-one-region-model/one-region-model.jl
+++ b/examples/tutorial/01-one-region-model/one-region-model.jl
@@ -42,7 +42,7 @@ end
 
 my_model = Model()
 
-setindex(my_model, :time, [2015:5:2110])
+setindex(my_model, :time, collect(2015:5:2110))
 
 addcomponent(my_model, grosseconomy)  #Order matters here. If the emissions component were defined first, the model would not run.
 addcomponent(my_model, emissions)

--- a/examples/tutorial/02-two-region-model/two-region-model.jl
+++ b/examples/tutorial/02-two-region-model/two-region-model.jl
@@ -5,7 +5,7 @@ function run_my_model()
 
     my_model = Model()
 
-    setindex(my_model, :time, [2015:5:2110])
+    setindex(my_model, :time, collect(2015:5:2110))
     setindex(my_model, :regions, ["Region1", "Region2", "Region3"])  #Note that the regions of your model must be specified here
 
     addcomponent(my_model, grosseconomy)


### PR DESCRIPTION
Change tutorial `:time` index definitions from `[2015:5:2110]` to `collect(2015:5:2110)`. With this change, the examples in the `oneregion` and `multiregion` tutorials work.

Addresses #2 