### PR TITLE
Forces conversion to model type

### DIFF
--- a/src/mimi-core.jl
+++ b/src/mimi-core.jl
@@ -402,7 +402,8 @@ Add an array type parameter to the model.
 """
 function set_external_array_parameter(m::Model, name::Symbol, value::AbstractArray, dims)
     if !(typeof(value) <: Array{m.numberType})
-        value = convert(Array{m.numberType}, value)
+        # Need to force a conversion (simple convert may alias in v0.6)
+        value = Array{m.numberType}(value)
     end
     p = ArrayModelParameter(value, (dims!=nothing)?(dims):(Vector{Symbol}()))
     m.external_parameters[name] = p


### PR DESCRIPTION
The `convert(Array{T}, x)` call is prone to alias to x in Julia 0.6.  What we really want to do (and here just do explicitly) is allocate a new array of type T to ensure that it is the right type.