### PR TITLE
make dict type {Any, Any} for setleftoverparams

### DIFF
--- a/src/mimi-core.jl
+++ b/src/mimi-core.jl
@@ -570,7 +570,7 @@ Set all the parameters in a model that don't have a value and are not connected
 to some other component to a value from a dictionary. This method assumes the dictionary
 keys are strings that match the names of unset parameters in the model.
 """
-function setleftoverparameters(m::Model, parameters::Dict{String,Any})
+function setleftoverparameters(m::Model, parameters::Dict{Any,Any})
     parameters = Dict(lowercase(k)=>v for (k, v) in parameters)
     leftovers = get_unconnected_parameters(m)
     for (comp, p) in leftovers

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -11,7 +11,8 @@ end
 
 #list of URLs of branches of packages to test
 dependencies = [
-"https://github.com/davidanthoff/fund.jl/archive/774a8c382b44de83601ae25b425cddc6c3a449a1.zip",
+#"https://github.com/davidanthoff/fund.jl/archive/774a8c382b44de83601ae25b425cddc6c3a449a1.zip",    # old version
+"https://github.com/davidanthoff/fund.jl/archive/9646dc3083100db49a0334d61ac54299c99b01e5.zip",     # newest version
 "https://github.com/anthofflab/mimi-rice-2010.jl/archive/d10a6687d77eba56d658817815d3edaadc1cb115.zip"
 ]
 


### PR DESCRIPTION
the helper function "loadparameters" in Fund was changed and now requires the setleftoverparameters dict type to be {Any, Any}