### PR TITLE
Add length method for TimestepVector

### DIFF
--- a/src/timestep_arrays.jl
+++ b/src/timestep_arrays.jl
@@ -82,6 +82,10 @@ function Base.endof(v::TimestepVector)
 	return length(v.data)
 end
 
+function Base.length(v::TimestepVector)
+	return length(v.data)
+end
+
 ################
 #  TimestepMatrix  #
 ################


### PR DESCRIPTION
We'll need this for PAGE. No need to merge anytime soon, I just wanted to make sure we don't forget about it. I would say we only merge this after @rjplevin's dot-overloading branch is merged.