### PR TITLE
Performance tweaks

### DIFF
--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -62,13 +62,14 @@ function _instantiate_datum(md::ModelDef, def::DatumDef, start::Int)
     elseif num_dims == 1 && dims[1] == :time
         value = dtype(dim_count(md, :time))
 
-    else # if dims[1] != :time  # TBD: this can be collapsed with final "else" clause"
+    else # if dims[1] != :time
         # TBD: Handle unnamed indices properly
         counts = dim_counts(md, Vector{Symbol}(dims))
         value = dtype(counts...)
     end
 
-    return Ref{dtype}(value)
+    T = typeof(value)
+    return Ref{T}(value)
 end
 
 """
@@ -153,6 +154,12 @@ function build(md::ModelDef)
     instantiate_components(mi)
 
     comps = mi.components
+
+    # Save dimension dictionary with which we call run_timestep
+    dim_dict = dim_value_dict(mi.md)
+    for ci in values(comps)
+        ci.dim_dict = dim_dict
+    end
 
     # Make the internal parameter connections, including hidden connections between ConnectorComps.
     for ipc in internal_param_conns(md)

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -60,8 +60,10 @@ function _generate_run_func(module_name, comp_name, args, body)
     func = :(
         function Mimi.run_timestep(::Val{$(QuoteNode(module_name))}, ::Val{$(QuoteNode(comp_name))}, 
                                    $(p)::Mimi.ComponentInstanceParameters, $(v)::Mimi.ComponentInstanceVariables, 
-                                   $(d)::Dict{Symbol, Vector{Int}}, $(t))
+                                   $(d)::Dict{Symbol, Vector{Int}}, $(t)::Union{Int, Mimi.Timestep})
             $(body...)
+            
+            return nothing
         end
     )
     func = esc(func)

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -136,13 +136,13 @@ unit(def::DatumDef) = def.unit
 
 function step_size(md::ModelDef)
     # N.B. assumes that all timesteps of the model are the same length
-    keys = dim_keys(md, :time) # keys are, e.g., the years the model runs
+    keys::Vector{Int} = dim_keys(md, :time) # keys are, e.g., the years the model runs
     return length(keys) > 1 ? keys[2] - keys[1] : 1
 end
 
 function step_size(values::Vector{Int})
     # N.B. assumes that all timesteps of the model are the same length
-    return length(values) > 1 ? values[2] - values[1] : 1
+     return length(values) > 1 ? values[2] - values[1] : 1
 end
 
 function check_parameter_dimensions(md::ModelDef, value::AbstractArray, dims::Vector, name::Symbol)

--- a/src/core/dimensions.jl
+++ b/src/core/dimensions.jl
@@ -51,11 +51,11 @@ Base.values(dim::RangeDimension) = collect(1:length(dim.range))
 #
 # Compute the index of a "key" (e.g., a year) in the range. 
 #
-function Base.get(dim::RangeDimension, key::Int64, default::Any=0) 
+function Base.get(dim::RangeDimension, key::Int, default::Any=0) 
     r = dim.range
     i = key - r.start
     return i == 0 ? 1 : (i % r.step != 0 ? default : 1 + div(i, r.step))
 end
 
 # Support dim[[2010, 2020, 2030]], dim[(:foo, :bar, :baz)], and dim[2010:2050]
-Base.getindex(dim::RangeDimension, keys::Union{Vector{Int64}, Tuple, Range}) = [get(dim, key, 0) for key in keys]
+Base.getindex(dim::RangeDimension, keys::Union{Vector{Int}, Tuple, Range}) = [get(dim, key, 0) for key in keys]

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -237,7 +237,8 @@ end
 
 Run model `m` once.
 """
-function Base.run(m::Model; ntimesteps=typemax(Int), dim_keys::Union{Void, Dict}=nothing)
+function Base.run(m::Model; ntimesteps::Int=typemax(Int), 
+                  dim_keys::Union{Void, Dict{Symbol, Vector{T} where T <: DimensionKeyTypes}}=nothing)
     if numcomponents(m) == 0
         error("Cannot run a model with no components.")
     end
@@ -248,6 +249,7 @@ function Base.run(m::Model; ntimesteps=typemax(Int), dim_keys::Union{Void, Dict}
 
     # println("Running model...")
     run(m.mi, ntimesteps, dim_keys)
+    nothing
 end
 
 #

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -27,7 +27,7 @@ function next_timestep{Start, Step, Stop}(ts::Timestep{Start, Step, Stop})
 end
 
 function new_timestep{Start, Step, Stop}(ts::Timestep{Start, Step, Stop}, new_start::Int)
-	return Timestep{new_start, Step, Stop}(Int64(ts.t + (Start - new_start) / Step))
+	return Timestep{new_start, Step, Stop}(Int(ts.t + (Start - new_start) / Step))
 end
 
 #
@@ -99,7 +99,7 @@ function Base.getindex(x::TimestepVector{T, Start, Step}, ts::Timestep{Start, St
 end
 
 function Base.getindex(x::TimestepVector{T, d_start, Step}, ts::Timestep{t_start, Step, Stop}) where {T, d_start, Step, t_start, Stop}
-	t = Int64(ts.t + (t_start - d_start) / Step)
+	t = Int(ts.t + (t_start - d_start) / Step)
 	return x.data[t]
 end
 
@@ -117,7 +117,7 @@ function Base.setindex!(v::TimestepVector{T, Start, Step}, val, ts::Timestep{Sta
 end
 
 function Base.setindex!(v::TimestepVector{T, d_start, Step}, val, ts::Timestep{t_start, Step, Stop}) where {T, d_start, Step, t_start, Stop}
-	t = Int64(ts.t + (t_start - d_start) / Step)
+	t = Int(ts.t + (t_start - d_start) / Step)
 	setindex!(v.data, val, t)
 end
 
@@ -148,7 +148,7 @@ function Base.getindex(mat::TimestepMatrix{T, Start, Step}, ts::Timestep{Start, 
 end
 
 function Base.getindex(mat::TimestepMatrix{T, d_start, Step}, ts::Timestep{t_start, Step, Stop}, i::AnyIndex) where {T, d_start, Step, t_start, Stop}
-	t = Int64(ts.t + (t_start - d_start) / Step)
+	t = Int(ts.t + (t_start - d_start) / Step)
 	return mat.data[t, i]
 end
 
@@ -162,7 +162,7 @@ function Base.setindex!(mat::TimestepMatrix{T, Start, Step}, val, ts::Timestep{S
 end
 
 function Base.setindex!(mat::TimestepMatrix{T, d_start, Step}, val, ts::Timestep{t_start, Step, Stop}, idx::AnyIndex) where {T, d_start, Step, t_start, Stop}
-	t = Int64(ts.t + (t_start - d_start) / Step)
+	t = Int(ts.t + (t_start - d_start) / Step)
 	setindex!(mat.data, val, t, idx)
 end
 

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -294,7 +294,7 @@ mutable struct ComponentInstance
     comp_id::ComponentId
     variables::ComponentInstanceVariables
     parameters::ComponentInstanceParameters
-    dimensions::Vector{Symbol}
+    dim_dict::Union{Void, Dict{Symbol, Vector{Int}}}
 
     start::Int
     stop::Int
@@ -306,7 +306,7 @@ mutable struct ComponentInstance
         self = new()
         self.comp_id = comp_def.comp_id
         self.comp_name = name
-        self.dimensions = map(dim -> dim.name, dimensions(comp_def))
+        self.dim_dict = nothing     # set in "build" stage
         self.variables = vars
         self.parameters = pars
         self.start = comp_def.start

--- a/src/mcs/EmpiricalDistribution.jl
+++ b/src/mcs/EmpiricalDistribution.jl
@@ -35,8 +35,8 @@ end
 
 """
 EmpiricalDistribution(file::Union{AbstractString, IO}, 
-                      value_col::Union{Symbol, String, Int64},
-                      prob_col::Union{Void, Symbol, String, Int64}=nothing)
+                      value_col::Union{Symbol, String, Int},
+                      prob_col::Union{Void, Symbol, String, Int}=nothing)
 
 Load empirical values from a CSV or XLS(X) file and generate a distribution. 
 
@@ -48,8 +48,8 @@ If an XLS or XLSX file is given, the `value_col` and `prob_col` should be fully 
 Excel data ranges, e.g., "Sheet1!A2:A1002", indicating the values to extract from the file.
 """
 function EmpiricalDistribution(filename::AbstractString,
-                               value_col::Union{Symbol, AbstractString, Int64},
-                               prob_col::Union{Void, Symbol, AbstractString, Int64}=nothing;
+                               value_col::Union{Symbol, AbstractString, Int},
+                               prob_col::Union{Void, Symbol, AbstractString, Int}=nothing;
                                value_type::DataType=Any)
     probs = nothing
     ext = splitext(lowercase(filename))[2]
@@ -59,7 +59,7 @@ function EmpiricalDistribution(filename::AbstractString,
         values = isa(value_col, Symbol) ? df[value_col] : df.columns[value_col]
         
         if prob_col != nothing
-            probs = isa(prob_col, Symbol) ? df[prob_col] : df.columns[prob_col]
+            probs = Vector{Float64}(isa(prob_col, Symbol) ? df[prob_col] : df.columns[prob_col])
         end
     elseif ext in (".xls", ".xlsx", ".xlsm")
 
@@ -68,12 +68,12 @@ function EmpiricalDistribution(filename::AbstractString,
         end
         
         f = openxl(filename)
-        data = readxl(f, value_col)
-        values = Vector{value_type}(data[:,1])
+        data = Array{value_type, 2}(readxl(f, value_col))
+        values = data[:, 1]
 
         if prob_col != nothing
-            data = readxl(f, prob_col)
-            probs = Vector{Float64}(data[:,1])
+            data = Array{Float64, 2}(readxl(f, prob_col))
+            probs = data[:, 1]
         end
     else
         error("Unrecognized file extension '$ext'. Must be .csv, .xls, .xlsx, or .xlsm")

--- a/src/mcs/lhs.jl
+++ b/src/mcs/lhs.jl
@@ -104,7 +104,7 @@ function _get_percentiles(trials::Int)
 end
 
 """
-    lhs(rvlist::Vector{RandomVariable}, trials::Int64; corrmatrix::Union{Matrix{Float64},Void}=nothing, asDataFrame::Bool=true)
+    lhs(rvlist::Vector{RandomVariable}, trials::Int; corrmatrix::Union{Matrix{Float64},Void}=nothing, asDataFrame::Bool=true)
              
 Produce an array or DataFrame of 'trials' rows of values for the given parameter
 list, respecting the correlation matrix 'corrmatrix' if one is specified, using Latin
@@ -130,7 +130,7 @@ skip: (list of params)) Parameters to process later because they are
 
 Returns DataFrame with `trials` rows of values for the `rvlist`.
 """
-function lhs(rvlist::Vector{RandomVariable}, trials::Int64; 
+function lhs(rvlist::Vector{RandomVariable}, trials::Int; 
              corrmatrix::Union{Matrix{Float64},Void}=nothing,
              asDataFrame::Bool=true)
 

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -37,7 +37,7 @@ const CorrelationSpec = Tuple{Symbol, Symbol, Float64}
 Holds all the data that defines a Monte Carlo simulation.
 """
 mutable struct MonteCarloSimulation
-    trials::Int64
+    trials::Int
     rvlist::Vector{RandomVariable}
     translist::Vector{TransformSpec}
     corrlist::Union{Vector{CorrelationSpec}, Void}

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -1,4 +1,4 @@
-function store_trial_results(m::Model, mcs::MonteCarloSimulation, trialnum::Int64)
+function store_trial_results(m::Model, mcs::MonteCarloSimulation, trialnum::Int)
     for datum_key in mcs.savelist
         # println("\nStoring trial results for $datum_key")
         (comp_name, datum_name) = datum_key
@@ -67,11 +67,11 @@ function save_trial_inputs(mcs::MonteCarloSimulation, filename::String)
 end
 
 """
-    generate_trials!(mcs::MonteCarloSimulation, trials::Int64; filename::String="")
+    generate_trials!(mcs::MonteCarloSimulation, trials::Int; filename::String="")
 
 Generate the given number of trials for the given MonteCarloSimulation instance.
 """
-function generate_trials!(mcs::MonteCarloSimulation, trials::Int64; filename::String="")
+function generate_trials!(mcs::MonteCarloSimulation, trials::Int; filename::String="")
     corrmatrix = correlation_matrix(mcs)
     mcs.data = lhs(mcs.rvlist, trials, corrmatrix=corrmatrix)
     mcs.trials = trials
@@ -83,11 +83,11 @@ end
 
 # TBD: precompute as much of this as possible to get it out of the MCS trial loop
 """
-    _perturb_parameters(m::Model, mcs::MonteCarloSimulation, trialnum::Int64)
+    _perturb_parameters(m::Model, mcs::MonteCarloSimulation, trialnum::Int)
 
 Modify the stochastic parameters using the values drawn for trial `trialnum`.
 """
-function _perturb_parameters(m::Model, mcs::MonteCarloSimulation, trialnum::Int64)
+function _perturb_parameters(m::Model, mcs::MonteCarloSimulation, trialnum::Int)
     if trialnum > mcs.trials
         error("Attempted to run trial $trialnum, but only $(mcs.trials) trials are defined")
     end
@@ -175,14 +175,14 @@ end
 # 2. 
 
 """
-    run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Union{Vector{Int64}, Range{Int64}}; ntimesteps=typemax(Int), pretrial_func=nothing, posttrial_func=nothing)
+    run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Union{Vector{Int}, Range{Int}}; ntimesteps=typemax(Int), pretrial_func=nothing, posttrial_func=nothing)
 
 Run the indicated trial numbers, where the model is run for `ntimesteps`, if specified, or to 
 the maximum defined time period otherswise. If `pretrial_func` or `posttrial_func` are defined,
 the designated functions are called just before or after (respectively) running the trial. The 
-functions must have the signature fn(m::Model, mcs::MonteCarloSimulation, trialnum::Int64).
+functions must have the signature fn(m::Model, mcs::MonteCarloSimulation, trialnum::Int).
 """
-function run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Union{Vector{Int64}, Range{Int64}}; 
+function run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Union{Vector{Int}, Range{Int}}; 
                  ntimesteps=typemax(Int), output_dir=nothing, 
                  pre_trial_func=nothing, post_trial_func=nothing)
     if m.mi == nothing
@@ -214,12 +214,12 @@ function run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Union{Vector{Int64
 end
 
 """
-    run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Int64=mcs.trials; ntimesteps=typemax(Int))
+    run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Int=mcs.trials; ntimesteps=typemax(Int))
 
 Run the indicated number of trials, where the model is run for `ntimesteps`, if specified, or to 
 the maximum defined time period otherswise.
 """
-function run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Int64=mcs.trials; 
+function run_mcs(m::Model, mcs::MonteCarloSimulation, trials::Int=mcs.trials; 
                  ntimesteps=typemax(Int), output_dir=nothing, 
                  pre_trial_func=nothing, post_trial_func=nothing)
     return run_mcs(m, mcs, 1:trials, ntimesteps=ntimesteps, output_dir=output_dir, 

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -4,10 +4,10 @@
 Linearly interpolate annual values from a vector of values
 for timestep of length `ts`.
 """
-function interpolate(values, ts=10)
+function interpolate(values::Vector{T}, ts::Int=10) where T <: Union{Float64, Int}
     count = length(values)
     newvalues = zeros((count-1) * ts + 1)
-    fracs = collect(range(0.0, 0.1, ts))
+    fracs = collect(range(0.0, 1/ts, ts))
 
     for i = 1:count - 1
         start = values[i]


### PR DESCRIPTION
Various adjustments to type declarations intended to improve performance. Also eliminated some redundant dict creation that was causing a lot of unnecessary allocation. Shaved about 25% off total time to run EPA-DICE (for 1000 trials across all scenarios / discount rates) from 60 min to 45 min. More remains to be done...