### PR TITLE
Extends getdataframe to >2 dims

### DIFF
--- a/src/mimi-core.jl
+++ b/src/mimi-core.jl
@@ -500,6 +500,7 @@ function getdataframe(m::Model, mi::ModelInstance, componentname::Symbol, name::
     meta_component_name = Symbol(supertype(typeof(mi.components[componentname])).name.name)
 
     vardiminfo = getdiminfoforvar((meta_module_name,meta_component_name), name)
+
     if length(vardiminfo)==0
         return mi[componentname, name]
     elseif length(vardiminfo)==1
@@ -507,17 +508,34 @@ function getdataframe(m::Model, mi::ModelInstance, componentname::Symbol, name::
         df[vardiminfo[1]] = m.indices_values[vardiminfo[1]]
         df[name] = mi[componentname, name]
         return df
-    elseif length(vardiminfo)==2
+    else
+        return getdataframe_helper(m, name, vardiminfo, mi[componentname, name])
+    end
+end
+
+function getdataframe_helper(m::Model, name::Symbol, vardiminfo::Array{Any}, data::AbstractArray)
+    if length(vardiminfo)==2
         df = DataFrame()
         dim1 = length(m.indices_values[vardiminfo[1]])
         dim2 = length(m.indices_values[vardiminfo[2]])
         df[vardiminfo[1]] = repeat(m.indices_values[vardiminfo[1]],inner=[dim2])
         df[vardiminfo[2]] = repeat(m.indices_values[vardiminfo[2]],outer=[dim1])
-        data = m[componentname, name]
         df[name] = cat(1,[vec(data[i,:]) for i=1:dim1]...)
         return df
     else
-        error("Not yet implemented")
+        # Initial blank DF
+        df = DataFrame()
+
+        # Indexes is #, :, :, ... for each index of first dimension
+        indexes = repmat(Any[Colon()], length(vardiminfo))
+        for ii in 1:size(data)[1]
+            indexes[1] = ii
+            subdf = getdataframe_helper(m, name, vardiminfo[2:end], data[indexes...])
+            subdf[vardiminfo[1]] = m.indices_values[vardiminfo[1]][ii]
+            df = vcat(df, subdf)
+        end
+
+        return df
     end
 end
 


### PR DESCRIPTION
Adds support for variables/parameters of greater than 2 dimensions in `getdataframe`.

I'm not sure if this is applicable to `master`, since it depends on whether `_load_dataframe` or `_load_dataframe_NEW` ends up going into the new version, but since I needed it for myself anyway, I thought I'd share it.