### PR TITLE
Macro to aid in debugging by importing all symbols from a package.

### DIFF
--- a/wip/export_all.jl
+++ b/wip/export_all.jl
@@ -1,0 +1,15 @@
+#
+# To simplify debugging, export all symbols for use in REPL
+#
+macro import_all(pkg)
+    function ok_to_import(symbol)
+        ! (symbol in (:eval, :show) || string(symbol)[1] == '#')
+    end
+
+    symbols = Iterators.filter(ok_to_import, names(eval(pkg), true))
+    symlist = join(symbols, ",")
+    return parse("import $pkg: $symlist")
+end
+
+using Mimi
+@import_all(Mimi)


### PR DESCRIPTION
Added macro `@import_all` in wip folder.