### PR TITLE
Fix Time Labels

### DIFF
--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -23,7 +23,7 @@ function _instance_datatype(md::ModelDef, def::DatumDef, start::Int)
             #need to make sure we define the tiemstp to begin at the start from 
             #the function argument
             start_index = findfirst(times, start)
-            T = TimestepArray{VariableTimestep{times[start_index:end]}, dtype, num_dims}
+            T = TimestepArray{VariableTimestep{(times[start_index:end]...)}, dtype, num_dims}
         end
     end
 

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -106,7 +106,7 @@ function connect_parameter(md::ModelDef,
         dst_dims  = dimensions(dst_param)
 
         backup = convert(Array{number_type(md)}, backup) # converts number type and, if it's a NamedArray, it's converted to Array
-        start = start_period(dst_comp_def)
+        first = first_period(dst_comp_def)
         T = eltype(backup)        
         
         dim_count = length(dst_dims)
@@ -116,14 +116,14 @@ function connect_parameter(md::ModelDef,
         else
             
             if isuniform(md)
-                #use the start from the comp_def not the ModelDef
+                #use the first from the comp_def not the ModelDef
                 _, stepsize = first_and_step(md)
-                values = TimestepArray{Timestep{start, stepsize}, T, dim_count}(backup)
+                values = TimestepArray{FixedTimestep{first, stepsize}, T, dim_count}(backup)
             else
                 times = time_labels(md)
-                #use the start from the comp_def 
-                start_index = findfirst(times, start)
-                values = TimestepArray{VariableTimestep{(times[start_index:end]...)}, T, dim_count}(backup)
+                #use the first from the comp_def 
+                first_index = findfirst(times, first)
+                values = TimestepArray{VariableTimestep{(times[first_index:end]...)}, T, dim_count}(backup)
             end
             
         end
@@ -209,7 +209,6 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
                 if num_dims in (1, 2) && param_dims[1] == :time   # array case
                     value = convert(Array{md.number_type}, value)
 
-                    times = time_labels(md)
                     values = get_timestep_instance(md, eltype(value), num_dims, value)
                     
                 else

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -96,7 +96,7 @@ function get_timestep_instance(md::ModelDef, T, num_dims, value)
 		return timestep_array_type{Timestep{start, stepsize}, T}(value)
 	else
 		start_times = time_labels(md)		
-		return timestep_array_type{VariableTimestep{start_times}, T}(value)	
+		return timestep_array_type{VariableTimestep{(start_times...)}, T}(value)	
 	end
 end
 


### PR DESCRIPTION
In working on PAGE I noticed a small error in `get_timestep_instance` code created by type parametrizing `VariableTimestep`with an array from `time_labels(md)`, so I went back to make sure this was splatted into a tuple in order to parameterize `VariableTimestep`