### PR TITLE
Add methods to set_external_param!

### DIFF
--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -202,7 +202,7 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
             param_dims = parameter_dimensions(md, comp_name, param_name)
             num_dims = length(param_dims)
 
-            set_external_param!(md, param_name, value, param_dims, num_dims)
+            set_external_param!(md, param_name, value; param_dims = param_dims, num_dims = num_dims)
             
             #TODO:  if tests pass and we like this change to set_external_param!, delete the commented out code below
             # if num_dims == 0    # scalar case
@@ -265,8 +265,8 @@ function set_external_param!(md::ModelDef, name::Symbol, value::ModelParameter; 
     md.external_params[name] = value
 end
 
-function set_external_param(md::ModelDef, name::Symbol, value::Number; param_dims = [], num_dims = 0)
-    set_external_scalar_param!(md, param_name, value)
+function set_external_param!(md::ModelDef, name::Symbol, value::Number; param_dims = [], num_dims = 0)
+    set_external_scalar_param!(md, name, value)
 end
 
 function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims = [], num_dims = 0)
@@ -280,7 +280,7 @@ function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractAr
          values = value
     end
 
-    set_external_array_param!(md, param_name, values, param_dims)
+    set_external_array_param!(md, name, values, param_dims)
 end
 
 """

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -199,26 +199,9 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
         # check whether we need to set the external parameter
         if ! haskey(md.external_params, param_name)
             value = parameters[string(param_name)]
-            param_dims = parameter_dimensions(md, comp_name, param_name)
-            num_dims = length(param_dims)
 
-            set_external_param!(md, param_name, value; param_dims = param_dims, num_dims = num_dims)
-            
-            #TODO:  if tests pass and we like this change to set_external_param!, delete the commented out code below
-            # if num_dims == 0    # scalar case
-            #     set_external_scalar_param!(md, param_name, value)
+            set_external_param!(md, param_name, value; comp_name = comp_name)
 
-            # else
-            #     if num_dims in (1, 2) && param_dims[1] == :time   # array case
-            #         value = convert(Array{md.number_type}, value)
-
-            #         values = get_timestep_instance(md, eltype(value), num_dims, value)
-                    
-            #     else
-            #         values = value
-            #     end
-            #     set_external_array_param!(md, param_name, values, param_dims)
-            # end
         end
         connect_parameter(md, comp_name, param_name, param_name)
     end
@@ -261,15 +244,18 @@ function add_external_param_conn(md::ModelDef, conn::ExternalParameterConnection
     push!(md.external_param_conns, conn)
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::ModelParameter; param_dims = [], num_dims = 0)
+function set_external_param!(md::ModelDef, name::Symbol, value::ModelParameter)
     md.external_params[name] = value
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::Number; param_dims = [], num_dims = 0)
+function set_external_param!(md::ModelDef, name::Symbol, value::Number; comp_name = comp_name)
     set_external_scalar_param!(md, name, value)
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims = [], num_dims = 0)
+function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; comp_name = comp_name)
+    
+    param_dims = parameter_dimensions(md, comp_name, name)
+    num_dims = length(param_dims)
 
     if num_dims in (1, 2) && param_dims[1] == :time   
         value = convert(Array{md.number_type}, value)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -249,11 +249,11 @@ function set_external_param!(md::ModelDef, name::Symbol, value::ModelParameter)
     md.external_params[name] = value
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::Number; param_dims::Array{Symbol} = nothing)
+function set_external_param!(md::ModelDef, name::Symbol, value::Number; param_dims::Union{Void,Array{Symbol}} = nothing)
     set_external_scalar_param!(md, name, value)
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims::Array{Symbol} = nothing)
+function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims::Union{Void,Array{Symbol}} = nothing)
     
     num_dims = length(param_dims)
 

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -202,7 +202,7 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
             param_dims = parameter_dimensions(md, comp_name, param_name)
             num_dims = length(param_dims)
 
-            set_external_param!(md, param_name, value)
+            set_external_param!(md, param_name, value, param_dims, num_dims)
             
             #TODO:  if tests pass and we like this change to set_external_param!, delete the commented out code below
             # if num_dims == 0    # scalar case

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -248,11 +248,11 @@ function set_external_param!(md::ModelDef, name::Symbol, value::ModelParameter)
     md.external_params[name] = value
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::Number; comp_name = comp_name)
+function set_external_param!(md::ModelDef, name::Symbol, value::Number; comp_name::Symbol = nothing)
     set_external_scalar_param!(md, name, value)
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; comp_name = comp_name)
+function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; comp_name::Symbol = nothing)
     
     param_dims = parameter_dimensions(md, comp_name, name)
     num_dims = length(param_dims)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -202,20 +202,22 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
             param_dims = parameter_dimensions(md, comp_name, param_name)
             num_dims = length(param_dims)
 
-            if num_dims == 0    # scalar case
-                set_external_scalar_param!(md, param_name, value)
+            set_external_param!(md, param_name, value)
 
-            else
-                if num_dims in (1, 2) && param_dims[1] == :time   # array case
-                    value = convert(Array{md.number_type}, value)
+            # if num_dims == 0    # scalar case
+            #     set_external_scalar_param!(md, param_name, value)
 
-                    values = get_timestep_instance(md, eltype(value), num_dims, value)
+            # else
+            #     if num_dims in (1, 2) && param_dims[1] == :time   # array case
+            #         value = convert(Array{md.number_type}, value)
+
+            #         values = get_timestep_instance(md, eltype(value), num_dims, value)
                     
-                else
-                    values = value
-                end
-                set_external_array_param!(md, param_name, values, param_dims)
-            end
+            #     else
+            #         values = value
+            #     end
+            #     set_external_array_param!(md, param_name, values, param_dims)
+            # end
         end
         connect_parameter(md, comp_name, param_name, param_name)
     end
@@ -258,8 +260,26 @@ function add_external_param_conn(md::ModelDef, conn::ExternalParameterConnection
     push!(md.external_param_conns, conn)
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::ModelParameter)
+function set_external_param!(md::ModelDef, name::Symbol, value::ModelParameter; param_dims = [], num_dims = 0)
     md.external_params[name] = value
+end
+
+function set_external_param(md::ModelDef, name::Symbol, value::Number; param_dims = [], num_dims = 0)
+    set_external_scalar_param!(md, param_name, value)
+end
+
+function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims = [], num_dims = 0)
+
+    if num_dims in (1, 2) && param_dims[1] == :time   
+        value = convert(Array{md.number_type}, value)
+
+        values = get_timestep_instance(md, eltype(value), num_dims, value)
+                 
+    else
+         values = value
+    end
+
+    set_external_array_param!(md, param_name, values, param_dims)
 end
 
 """

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -199,8 +199,9 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
         # check whether we need to set the external parameter
         if ! haskey(md.external_params, param_name)
             value = parameters[string(param_name)]
+            param_dims = parameter_dimensions(md, comp_name, param_name)
 
-            set_external_param!(md, param_name, value; comp_name = comp_name)
+            set_external_param!(md, param_name, value; param_dims = param_dims)
 
         end
         connect_parameter(md, comp_name, param_name, param_name)
@@ -248,13 +249,12 @@ function set_external_param!(md::ModelDef, name::Symbol, value::ModelParameter)
     md.external_params[name] = value
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::Number; comp_name::Symbol = nothing)
+function set_external_param!(md::ModelDef, name::Symbol, value::Number; param_dims::Array{Symbol} = nothing)
     set_external_scalar_param!(md, name, value)
 end
 
-function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; comp_name::Symbol = nothing)
+function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims::Array{Symbol} = nothing)
     
-    param_dims = parameter_dimensions(md, comp_name, name)
     num_dims = length(param_dims)
 
     if num_dims in (1, 2) && param_dims[1] == :time   

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -203,7 +203,8 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
             num_dims = length(param_dims)
 
             set_external_param!(md, param_name, value)
-
+            
+            #TODO:  if tests pass and we like this change to set_external_param!, delete the commented out code below
             # if num_dims == 0    # scalar case
             #     set_external_scalar_param!(md, param_name, value)
 

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -67,12 +67,12 @@ function set_external_param!(m::Model, name::Symbol, value::ModelParameter)
     decache(m)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::Number; comp_name = comp_name)
+function set_external_param!(m::Model, name::Symbol, value::Number; comp_name::Symbol = nothing)
     set_external_param!(m.md, name, value; comp_name = comp_name)
     decache(m)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; comp_name = comp_name)
+function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; comp_name::Symbol = nothing)
     set_external_param!(m.md, name, value; comp_name = comp_name)
 end
 

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -67,13 +67,13 @@ function set_external_param!(m::Model, name::Symbol, value::ModelParameter)
     decache(m)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::Number; comp_name::Symbol = nothing)
-    set_external_param!(m.md, name, value; comp_name = comp_name)
+function set_external_param!(m::Model, name::Symbol, value::Number; param_dims::Array{Symbol} = nothing)
+    set_external_param!(m.md, name, value; param_dims = param_dims)
     decache(m)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; comp_name::Symbol = nothing)
-    set_external_param!(m.md, name, value; comp_name = comp_name)
+function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims::Array{Symbol} = nothing)
+    set_external_param!(m.md, name, value; param_dims = param_dims)
 end
 
 function add_internal_param_conn(m::Model, conn::InternalParameterConnection)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -73,7 +73,7 @@ function set_external_param!(m::Model, name::Symbol, value::Number; param_dims =
 end
 
 function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims = [], num_dims = 0)
-    set_external_param!(m.md, name, value, param_dims, num_dims)
+    set_external_param!(m.md, name, value; param_dims = param_dims, num_dims = num_dims)
 end
 
 function add_internal_param_conn(m::Model, conn::InternalParameterConnection)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -67,12 +67,12 @@ function set_external_param!(m::Model, name::Symbol, value::ModelParameter)
     decache(m)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::Number; param_dims::Array{Symbol} = nothing)
+function set_external_param!(m::Model, name::Symbol, value::Number; param_dims::Union{Void,Array{Symbol}} = nothing)
     set_external_param!(m.md, name, value; param_dims = param_dims)
     decache(m)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims::Array{Symbol} = nothing)
+function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims::Union{Void,Array{Symbol}} = nothing)
     set_external_param!(m.md, name, value; param_dims = param_dims)
 end
 

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -62,18 +62,18 @@ function connect_parameter(m::Model, dst::Pair{Symbol, Symbol}, src::Pair{Symbol
     connect_parameter(m.md, dst[1], dst[2], src[1], src[2], backup; ignoreunits=ignoreunits, offset=offset)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::ModelParameter; param_dims = [], num_dims = 0)
+function set_external_param!(m::Model, name::Symbol, value::ModelParameter)
     set_external_param!(m.md, name, value)
     decache(m)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::Number; param_dims = [], num_dims = 0)
-    set_external_param!(m.md, name, value)
+function set_external_param!(m::Model, name::Symbol, value::Number; comp_name = comp_name)
+    set_external_param!(m.md, name, value; comp_name = comp_name)
     decache(m)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims = [], num_dims = 0)
-    set_external_param!(m.md, name, value; param_dims = param_dims, num_dims = num_dims)
+function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; comp_name = comp_name)
+    set_external_param!(m.md, name, value; comp_name = comp_name)
 end
 
 function add_internal_param_conn(m::Model, conn::InternalParameterConnection)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -62,9 +62,18 @@ function connect_parameter(m::Model, dst::Pair{Symbol, Symbol}, src::Pair{Symbol
     connect_parameter(m.md, dst[1], dst[2], src[1], src[2], backup; ignoreunits=ignoreunits, offset=offset)
 end
 
-function set_external_param!(m::Model, name::Symbol, value::ModelParameter)
+function set_external_param!(m::Model, name::Symbol, value::ModelParameter; param_dims = [], num_dims = 0)
     set_external_param!(m.md, name, value)
     decache(m)
+end
+
+function set_external_param!(m::Model, name::Symbol, value::Number; param_dims = [], num_dims = 0)
+    set_external_param!(m.md, name, value)
+    decache(m)
+end
+
+function set_external_param!(m::Model, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims = [], num_dims = 0)
+    set_external_param!(m.md, name, value, param_dims, num_dims)
 end
 
 function add_internal_param_conn(m::Model, conn::InternalParameterConnection)


### PR DESCRIPTION
This PR adds methods to `set_external_param!` so that it has functionality to call `set_external_scalar_param!` and `set_external_array_param!`.  This allowed simplification of `set_leftover_params!`. 

Issue:  mimi-page-2009.jl Issue 2: setdistinctparameter()

**Outstanding Issues:** do we need to `decache(m)` after `set_external_param!`