### PR TITLE
Adds copy function for generic TimestepArray

### DIFF
--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -556,6 +556,10 @@ function Base.copy(obj::TimestepMatrix{T_ts, T}) where {T_ts, T}
     return TimestepMatrix{T_ts, T}(copy(obj.data))
 end
 
+function Base.copy(obj::TimestepArray{T_ts, T, N}) where {T_ts, T, N}
+    return TimestepArray{T_ts, T, N}(copy(obj.data))
+end
+
 """
     copy(md::ModelDef)
 


### PR DESCRIPTION
found that this wasn't defined while working on a 3-dimensional component, so it would error when trying to copy the external parameters. 