### PR TITLE
Fixed bug in processing declared type of model Parameters.

### DIFF
--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -1,7 +1,7 @@
 connector_comp_name(i::Int) = Symbol("ConnectorComp$i")
 
 # Return the datatype to use for instance variables/parameters
-function _instance_datatype(md::ModelDef, def::DatumDef, first::Int)
+function _instance_datatype(md::ModelDef, def::DatumDef, first::Int)    
     dtype = def.datatype == Number ? number_type(md) : def.datatype
     dims = dimensions(def)
     num_dims = dim_count(def)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -16,9 +16,9 @@ end
 function _check_labels(md::ModelDef, comp_def::ComponentDef, param_name::Symbol, ext_param::ArrayModelParameter)
     param_def = parameter(comp_def, param_name)
 
-    if !(eltype(ext_param.values) <: datatype(param_def))
-        t1 = eltype(ext_param.values)
-        t2 = datatype(param_def)
+    t1 = eltype(ext_param.values)
+    t2 = eltype(datatype(param_def))
+    if !(t1 <: t2)
         error("Mismatched datatype of parameter connection: Component: $(comp_def.comp_id) ($t1), Parameter: $param_name ($t2)")
     end
 

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -109,7 +109,7 @@ end
 # Generates an expression to construct a Variable or Parameter
 function _generate_var_or_param(elt_type, name, datatype, dimensions, dflt, desc, unit)
     func_name = elt_type == :Parameter ? :addparameter : :addvariable
-    args = [datatype, dimensions, desc, unit]
+    args = [eval(datatype), dimensions, desc, unit]
     if elt_type == :Parameter
         push!(args, dflt)
     end

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -107,7 +107,18 @@ function _check_for_known_element(name)
 end
 
 # Generates an expression to construct a Variable or Parameter
-function _generate_var_or_param(elt_type, name, datatype, dimensions, dflt, desc, unit)
+function _generate_var_or_param(elt_type, name, vartype, dimensions, dflt, desc, unit)
+    if vartype == nothing
+        # If no explicit type is given, use the type of the default
+        if (elt_type == :Parameter && dflt != nothing)
+            datatype = typeof(dflt)
+        else
+            datatype = Number
+        end
+    else
+        datatype = vartype
+    end
+
     func_name = elt_type == :Parameter ? :addparameter : :addvariable
     args = [eval(datatype), dimensions, desc, unit]
     if elt_type == :Parameter
@@ -253,8 +264,7 @@ macro defcomp(comp_name, ex)
             dims = Tuple(dimensions) # just for printing
             debug("    index $dims, unit '$unit', desc '$desc'")
 
-            datatype = vartype == nothing ? Number : vartype
-            addexpr(_generate_var_or_param(elt_type, name, datatype, dimensions, dflt, desc, unit))
+            addexpr(_generate_var_or_param(elt_type, name, vartype, dimensions, eval(dflt), desc, unit))
 
         else
             error("Unrecognized element type: $elt_type")

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -489,7 +489,7 @@ function add_comp!(md::ModelDef, comp_def::ComponentDef, comp_name::Symbol;
     # Set parameters to any specified defaults
     for param in parameters(comp_def)
         if param.default != nothing
-            set_param!(md, comp_name, name(param), param.default)
+            set_param!(md, comp_name, name(param), param.datatype(param.default))
         end
     end
     

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -295,7 +295,11 @@ function set_param!(md::ModelDef, comp_name::Symbol, param_name::Symbol, value, 
         dtype = data_type == Number ? number_type(md) : data_type
 
         # convert the number type and, if NamedArray, convert to Array
-        value = convert(Array{dtype, num_dims}, value)
+        if dtype <: AbstractArray
+            value = convert(dtype, value)
+        else
+            value = convert(Array{dtype, num_dims}, value)
+        end
         
         if comp_param_dims[1] == :time
             T = eltype(value)
@@ -489,7 +493,7 @@ function add_comp!(md::ModelDef, comp_def::ComponentDef, comp_name::Symbol;
     # Set parameters to any specified defaults
     for param in parameters(comp_def)
         if param.default != nothing
-            set_param!(md, comp_name, name(param), param.datatype(param.default))
+            set_param!(md, comp_name, name(param), param.default)
         end
     end
     


### PR DESCRIPTION
If a default was given as an Int, it would override the declaration of Parameter type, confounding a subsequent MCS which tries to store a float into this location.