### PR TITLE
Revised treatment of default parameter values and parameter types.

### DIFF
--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -25,7 +25,7 @@ is_builtin(module_name, comp_name) = (module_name == :Main && comp_name in built
 # :(setproperty!(p, Val(:foo), (getproperty(v, Val(:bar)))[1]))
 #
 function _replace_dots(ex)
-    debug("\nreplace_dots($ex)\n")
+    # debug("\nreplace_dots($ex)\n")
 
     if @capture(ex, obj_.field_ = rhs_)
         return :(setproperty!($obj, Val($(QuoteNode(field))), $rhs))
@@ -107,20 +107,9 @@ function _check_for_known_element(name)
 end
 
 # Generates an expression to construct a Variable or Parameter
-function _generate_var_or_param(elt_type, name, vartype, dimensions, dflt, desc, unit)
-    if vartype == nothing
-        # If no explicit type is given, use the type of the default
-        if (elt_type == :Parameter && dflt != nothing)
-            datatype = typeof(dflt)
-        else
-            datatype = Number
-        end
-    else
-        datatype = vartype
-    end
-
+function _generate_var_or_param(elt_type, name, datatype, dimensions, dflt, desc, unit)
     func_name = elt_type == :Parameter ? :addparameter : :addvariable
-    args = [eval(datatype), dimensions, desc, unit]
+    args = [datatype, dimensions, desc, unit]
     if elt_type == :Parameter
         push!(args, dflt)
     end
@@ -206,9 +195,6 @@ macro defcomp(comp_name, ex)
             error("Element syntax error: $elt")           
         end
 
-        # vartype = vartype == nothing ? ::Float64 : vartype
-        # debug("name: $name, vartype: $vartype, elt_type: $elt_type, args: $args")
-
         # elt_type is one of {:Variable, :Parameter, :Index}
         if elt_type == :Index
             expr = _generate_dims_expr(name, args, vartype)
@@ -253,6 +239,7 @@ macro defcomp(comp_name, ex)
                             push!(known_dims, dim)
                         end
                     end
+
                 elseif @capture(arg, default = dflt_)
                     if elt_type == :Variable
                         error("Default values are permitted only for Parameters, not for Variables")
@@ -261,10 +248,15 @@ macro defcomp(comp_name, ex)
                 end
             end
 
-            dims = Tuple(dimensions) # just for printing
-            debug("    index $dims, unit '$unit', desc '$desc'")
+            debug("    index $(Tuple(dimensions)), unit '$unit', desc '$desc'")
 
-            addexpr(_generate_var_or_param(elt_type, name, vartype, dimensions, eval(dflt), desc, unit))
+            dflt = eval(dflt)
+            if (dflt != nothing && length(dimensions) != ndims(dflt))
+                error("Default value has different number of dimensions ($(ndims(dflt))) than parameter '$name' ($(length(dimensions)))")
+            end
+
+            vartype = vartype == nothing ? Number : eval(vartype)
+            addexpr(_generate_var_or_param(elt_type, name, vartype, dimensions, dflt, desc, unit))
 
         else
             error("Unrecognized element type: $elt_type")

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -275,8 +275,6 @@ an array, or a NamedAray. Optional argument 'dims' is a list of the dimension na
 the provided data, and will be used to check that they match the model's index labels.
 """
 function set_param!(md::ModelDef, comp_name::Symbol, param_name::Symbol, value, dims=nothing)
-    comp_def = compdef(md, comp_name)
-
     # perform possible dimension and labels checks
     if isa(value, NamedArray)
         dims = dimnames(value)
@@ -289,18 +287,18 @@ function set_param!(md::ModelDef, comp_name::Symbol, param_name::Symbol, value, 
     comp_param_dims = parameter_dimensions(md, comp_name, param_name)
     num_dims = length(comp_param_dims)
     
-    if length(comp_param_dims) > 0
-        comp_def = compdef(md, comp_name)
-        data_type = datatype(parameter(comp_def, param_name))
-        dtype = data_type == Number ? number_type(md) : data_type
+    comp_def = compdef(md, comp_name)
+    data_type = datatype(parameter(comp_def, param_name))
+    dtype = data_type == Number ? number_type(md) : data_type
 
+    if length(comp_param_dims) > 0
         # convert the number type and, if NamedArray, convert to Array
         if dtype <: AbstractArray
             value = convert(dtype, value)
         else
             value = convert(Array{dtype, num_dims}, value)
         end
-        
+
         if comp_param_dims[1] == :time
             T = eltype(value)
 
@@ -319,9 +317,7 @@ function set_param!(md::ModelDef, comp_name::Symbol, param_name::Symbol, value, 
                     first_index = findfirst(times, first)                  
                     values = TimestepArray{VariableTimestep{(times[first_index:end]...)}, T, num_dims}(value)
                 end 
-                
             end
-
         else
             values = value
         end
@@ -329,6 +325,7 @@ function set_param!(md::ModelDef, comp_name::Symbol, param_name::Symbol, value, 
         set_external_array_param!(md, param_name, values, comp_param_dims)
 
     else # scalar parameter case
+        value = convert(dtype, value)
         set_external_scalar_param!(md, param_name, value)
     end
 

--- a/test/test_parametertypes.jl
+++ b/test/test_parametertypes.jl
@@ -5,13 +5,33 @@ import Mimi:
     external_params, update_external_param, TimestepMatrix, TimestepVector, 
     ArrayModelParameter, ScalarModelParameter, FixedTimestep
 
+#
+# Test that parameter type mismatches are caught
+#
+expr = @macroexpand @defcomp BadComp1 begin
+    a = Parameter(index=[time, regions], default=[10, 11, 12])  # should be 2D default
+    function run_timestep(p, v, d, t)
+    end
+end
+@test_throws ErrorException eval(expr)
+
+expr = @macroexpand @defcomp BadComp2 begin
+    a = Parameter(default=[10, 11, 12])  # should be scalar default
+    function run_timestep(p, v, d, t)
+    end
+end
+@test_throws ErrorException eval(expr)
+
+
 @defcomp MyComp begin
-    a = Parameter(index=[time, regions])
-    b = Parameter(index=[time])
+    a = Parameter(index=[time, regions], default=ones(101,3))
+    b = Parameter(index=[time], default=1:101)
     c = Parameter(index=[regions])
     d = Parameter()
     e = Parameter(index=[four])
     f::Array{Float64, 2} = Parameter()
+    g::Int = Parameter(default=10.0)    # value should be Int64 despite Float64 default
+    h = Parameter(default=10)           # should be "numtype", despite Int64 default
 
     x = Variable(index=[time, regions])
     
@@ -22,16 +42,19 @@ import Mimi:
     end
 end
 
-m = Model()
+# Check that explicit number type for model works as expected
+numtype = Float32
+m = Model(numtype)
+
 set_dimension!(m, :time, 2000:2100)
 set_dimension!(m, :regions, 3)
 set_dimension!(m, :four, 4)
 
 add_comp!(m, MyComp)
-set_param!(m, :MyComp, :a, ones(101,3))
-set_param!(m, :MyComp, :b, 1:101)
+# set_param!(m, :MyComp, :a, ones(101,3))
+# set_param!(m, :MyComp, :b, 1:101)
 set_param!(m, :MyComp, :c, [4,5,6])
-set_param!(m, :MyComp, :d, .5)
+set_param!(m, :MyComp, :d, 0.5)   # 32-bit float constant
 set_param!(m, :MyComp, :e, [1,2,3,4])
 set_param!(m, :MyComp, :f, [1.0 2.0; 3.0 4.0])
 
@@ -47,12 +70,14 @@ extpars = external_params(m)
 @test isa(extpars[:e], ArrayModelParameter)
 @test isa(extpars[:f], ScalarModelParameter) # note that :f is stored as a scalar parameter even though its values are an array
 
-@test typeof(extpars[:a].values) == TimestepMatrix{FixedTimestep{2000, 1}, Float64}
-@test typeof(extpars[:b].values) == TimestepVector{FixedTimestep{2000, 1}, Float64}
-@test typeof(extpars[:c].values) == Array{Float64, 1}
-@test typeof(extpars[:d].value) == Float64
-@test typeof(extpars[:e].values) == Array{Float64, 1}
+@test typeof(extpars[:a].values) == TimestepMatrix{FixedTimestep{2000, 1}, numtype}
+@test typeof(extpars[:b].values) == TimestepVector{FixedTimestep{2000, 1}, numtype}
+@test typeof(extpars[:c].values) == Array{numtype, 1}
+@test typeof(extpars[:d].value) == numtype
+@test typeof(extpars[:e].values) == Array{numtype, 1}
 @test typeof(extpars[:f].value) == Array{Float64, 2}
+@test typeof(extpars[:g].value) == Int64
+@test typeof(extpars[:h].value) == numtype
 
 # test updating parameters
 @test_throws ErrorException update_external_param(m, :a, 5) #expects an array
@@ -66,7 +91,7 @@ update_external_param(m, :d, 5) # should work, will convert to float
 @test_throws ErrorException update_external_param(m, :e, ones(10)) #wrong size
 update_external_param(m, :e, [4,5,6,7])
 
-@test length(extpars) == 6
-@test typeof(extpars[:a].values) == TimestepMatrix{FixedTimestep{2000, 1}, Float64}
-@test typeof(extpars[:d].value) == Float64
-@test typeof(extpars[:e].values) == Array{Float64, 1}
+@test length(extpars) == 8
+@test typeof(extpars[:a].values) == TimestepMatrix{FixedTimestep{2000, 1}, numtype}
+@test typeof(extpars[:d].value) == numtype
+@test typeof(extpars[:e].values) == Array{numtype, 1}


### PR DESCRIPTION
- Default values must have the same number of dimensions as the parameter (via the indexes=[...] option or lack thereof)
- Default values and other values are converted to the parameter's declared type (or lacking a declaration, to the Model's number_type) when set.
- Added tests for correct treatment of "number_type" applied to params of unspecified types