### PR TITLE
Fix random variable name key

### DIFF
--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -206,7 +206,7 @@ function Base.rand!(mcs::MonteCarloSimulation)
 
     for rv in mcs.dist_rvs
         values = rand(rv.dist, trials)
-        rvdict[name] = RandomVariable(rv.name, SampleStore(values))
+        rvdict[rv.name] = RandomVariable(rv.name, SampleStore(values))
     end
 end
 


### PR DESCRIPTION
I think this was a bug? Not sure why it wasn't always causing problems, but I just ran into an error that said "Can't convert to a Symbol", and this fixes it