### PR TITLE
update_param!

### DIFF
--- a/docs/src/integrationguide.md
+++ b/docs/src/integrationguide.md
@@ -105,7 +105,7 @@ The full API:
 
 ### Updating an external parameter
 
-The function `update_external_parameter` is now written as `update_external_param`.
+The function `update_external_parameter` is now written as `update_external_param!`, and `update_external_parameters` is now written as `udpate_external_params!`.  There is also a new optional argument `update_timesteps` which can be used if the external parameter being set has a `:time` dimension, and not only values pertaining to those times, but also time keys that are connected to those values have changed.
 
 ### Setting parameters with a dictionary
 

--- a/docs/src/integrationguide.md
+++ b/docs/src/integrationguide.md
@@ -105,7 +105,7 @@ The full API:
 
 ### Updating an external parameter
 
-The function `update_external_parameter` is now written as `update_external_param!`, and `update_external_parameters` is now written as `udpate_external_params!`.  There is also a new optional argument `update_timesteps` which can be used if the external parameter being set has a `:time` dimension, and not only values pertaining to those times, but also time keys that are connected to those values have changed.
+The function `update_external_parameter` is now written as `update_param!`, and `update_external_parameters` is now written as `udpate_params!`.  There is also a new optional argument `update_timesteps` which can be used if the external parameter being set has a `:time` dimension, and not only values pertaining to those times, but also time keys that are connected to those values have changed.
 
 ### Setting parameters with a dictionary
 

--- a/docs/src/integrationguide.md
+++ b/docs/src/integrationguide.md
@@ -105,11 +105,17 @@ The full API:
 
 ### Updating an external parameter
 
-The function `update_external_parameter` is now written as `update_param!`, and `update_external_parameters` is now written as `udpate_params!`.  There is also a new optional argument `update_timesteps` which can be used if the external parameter being set has a `:time` dimension, and not only values pertaining to those times, but also time keys that are connected to those values have changed.
+To update an external parameter, use the functions `update_param!` and `udpate_params!` (previously known as `update_external_parameter` and `update_external_parameters`, respectively.)  Their calling signatures are:
+
+*  `update_params!(md::ModelDef, parameters::Dict; update_timesteps = false)`
+
+* `update_param!(md::ModelDef, name::Symbol, value; update_timesteps = false)`
+
+For external parameters with a `:time` dimension, passing `update_timesteps=true` indicates that the time _keys_ (i.e., year labels) should also be updated in addition to updating the parameter values.
 
 ### Setting parameters with a dictionary
 
-The function `setleftoverparameters` is now written as `set_leftover_params!`.
+The function `set_leftover_params!` replaces the function `setleftoverparameters`.
 
 ### Using NamedArrays for setting parameters
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -30,5 +30,6 @@ set_leftover_params!
 setproperty!
 set_param! 
 variables  
+update_external_param!
 update_external_params!
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -30,4 +30,5 @@ set_leftover_params!
 setproperty!
 set_param! 
 variables  
+update_external_params!
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -30,6 +30,6 @@ set_leftover_params!
 setproperty!
 set_param! 
 variables  
-update_external_param!
-update_external_params!
+update_param!
+update_params!
 ```

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -217,10 +217,11 @@ In both of these cases, the parameter's values are stored of as an array (p1 is 
 
 ### Updating an external parameter
 
-When `set_param!` is called, it creates an external parameter by the name provided, and stores the provided value(s). It is possible to later change the value(s) associated with that parameter name. Use the following available function:
+When `set_param!` is called, it creates an external parameter by the name provided, and stores the provided value(s). It is possible to later change the value(s) associated with that parameter name. Use the following available function.  If the external parameter being set has a `:time` dimension, and not only values pertaining to those times, but also time keys that are connected to those values have changed, use the optional argument `update_timesteps` as shown below.
 
 ```julia
-update_external_param(mymodel, :parametername, newvalues)
+update_external_param(mymodel, :parametername, newvalues) #don't need to update timestep times
+update_external_param(mymodel, :parametername, newvalues, udpate_timesteps=true) #do need to update timestep times
 ```
 
 Note: newvalues must be the same size and type (or be able to convert to the type) of the old values stored in that parameter.

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -220,8 +220,8 @@ In both of these cases, the parameter's values are stored of as an array (p1 is 
 When `set_param!` is called, it creates an external parameter by the name provided, and stores the provided value(s). It is possible to later change the value(s) associated with that parameter name. Use the following available function.  If the external parameter being set has a `:time` dimension, and not only values pertaining to those times, but also time keys that are connected to those values have changed, use the optional argument `update_timesteps` as shown below.
 
 ```julia
-update_external_param!(mymodel, :parametername, newvalues) #don't need to update timestep times
-update_external_param!(mymodel, :parametername, newvalues, udpate_timesteps=true) #do need to update timestep times
+update_param!(mymodel, :parametername, newvalues) #don't need to update timestep times
+update_param!(mymodel, :parametername, newvalues, udpate_timesteps=true) #do need to update timestep times
 ```
 
 Note: newvalues must be the same size and type (or be able to convert to the type) of the old values stored in that parameter.
@@ -248,7 +248,7 @@ When a user sets a parameter, Mimi checks that the size and dimensions match wha
 instance1 = Mimi.build(mymodel)
 run(instance1)
 
-update_external_param(mymodel, paramname, newvalue)
+update_param!(mymodel, paramname, newvalue)
 instance2 = Mimi.build(mymodel)
 run(instance2)
 

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -217,11 +217,12 @@ In both of these cases, the parameter's values are stored of as an array (p1 is 
 
 ### Updating an external parameter
 
-When `set_param!` is called, it creates an external parameter by the name provided, and stores the provided value(s). It is possible to later change the value(s) associated with that parameter name. Use the following available function.  If the external parameter being set has a `:time` dimension, and not only values pertaining to those times, but also time keys that are connected to those values have changed, use the optional argument `update_timesteps` as shown below.
+When `set_param!` is called, it creates an external parameter by the name provided, and stores the provided scalar or array value. It is possible to later change the value associated with that parameter name using the functions described below. If the external parameter has a `:time` dimension, use the optional argument `update_timesteps=true` to indicate that the time keys (i.e., year labels) associated with the parameter should be updated in addition to updating the parameter values.
 
 ```julia
-update_param!(mymodel, :parametername, newvalues) #don't need to update timestep times
-update_param!(mymodel, :parametername, newvalues, udpate_timesteps=true) #do need to update timestep times
+update_param!(mymodel, :parametername, newvalues) # update values only 
+
+update_param!(mymodel, :parametername, newvalues, update_timesteps=true) # also update time keys
 ```
 
 Note: newvalues must be the same size and type (or be able to convert to the type) of the old values stored in that parameter.

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -220,8 +220,8 @@ In both of these cases, the parameter's values are stored of as an array (p1 is 
 When `set_param!` is called, it creates an external parameter by the name provided, and stores the provided value(s). It is possible to later change the value(s) associated with that parameter name. Use the following available function.  If the external parameter being set has a `:time` dimension, and not only values pertaining to those times, but also time keys that are connected to those values have changed, use the optional argument `update_timesteps` as shown below.
 
 ```julia
-update_external_param(mymodel, :parametername, newvalues) #don't need to update timestep times
-update_external_param(mymodel, :parametername, newvalues, udpate_timesteps=true) #do need to update timestep times
+update_external_param!(mymodel, :parametername, newvalues) #don't need to update timestep times
+update_external_param!(mymodel, :parametername, newvalues, udpate_timesteps=true) #do need to update timestep times
 ```
 
 Note: newvalues must be the same size and type (or be able to convert to the type) of the old values stored in that parameter.

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -41,8 +41,8 @@ export
     set_leftover_params!, 
     setproperty!, 
     set_param!, 
-    update_external_param!,
-    update_external_params!,
+    update_param!,
+    update_params!,
     variables 
 
 include("core/types.jl")

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -41,6 +41,7 @@ export
     set_leftover_params!, 
     setproperty!, 
     set_param!, 
+    update_external_params!,
     variables 
 
 include("core/types.jl")

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -41,6 +41,7 @@ export
     set_leftover_params!, 
     setproperty!, 
     set_param!, 
+    update_external_param!,
     update_external_params!,
     variables 
 

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -423,7 +423,7 @@ Boolean argument update_timesteps. Each key k must be a symbol or convert to a
 symbol matching the name of an external parameter that already exists in the 
 model definition.
 """
-function update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T 
+function update_external_params!(md::ModelDef, parameters::Dict; update_timesteps = false)
     parameters = Dict(Symbol(k) => v for (k, v) in parameters)
     for (param_name, value) in parameters
         update_external_param!(md, param_name, value; update_timesteps = update_timesteps)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -281,7 +281,7 @@ function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractAr
     if num_dims in (1, 2) && param_dims[1] == :time   
         value = convert(Array{md.number_type}, value)
 
-        values = get_timestep_instance(md, eltype(value), num_dims, value)
+        values = get_timestep_array(md, eltype(value), num_dims, value)
                  
     else
          values = value

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -232,6 +232,13 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
     nothing
 end
 
+"""
+    update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T
+
+For each (k, v) in the provided `parameters` dictionary, update_external_param! 
+is called to update the external parameter by name k to value v, with optional 
+Boolean argument update_timesteps.
+"""
 function update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T 
     parameters = Dict(Symbol(k) => v for (k, v) in parameters)
     for (param_name, value) in parameters

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -341,14 +341,14 @@ function set_external_scalar_param!(md::ModelDef, name::Symbol, value::Any)
 end
 
 """
-    update_external_param!(md::ModelDef, name::Symbol, value; update_timesteps = false)
+    update_param!(md::ModelDef, name::Symbol, value; update_timesteps = false)
 
 Update the `value` of an external model parameter in ModelDef `md`, referenced 
 by `name`. Optional boolean argument `update_timesteps` with default value 
 `false` indicates whether to update the time keys associated with the parameter 
 values to match the model's time index.
 """
-function update_external_param!(md::ModelDef, name::Symbol, value; update_timesteps = false)
+function update_param!(md::ModelDef, name::Symbol, value; update_timesteps = false)
     ext_params = md.external_params
     if ! haskey(ext_params, name)
         error("Cannot update parameter; $name not found in model's external parameters.")
@@ -415,18 +415,18 @@ function _update_array_param!(md::ModelDef, name, value, update_timesteps)
 end
 
 """
-    update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T
+    update_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T
 
-For each (k, v) in the provided `parameters` dictionary, update_external_param! 
+For each (k, v) in the provided `parameters` dictionary, update_param! 
 is called to update the external parameter by name k to value v, with optional 
 Boolean argument update_timesteps. Each key k must be a symbol or convert to a
 symbol matching the name of an external parameter that already exists in the 
 model definition.
 """
-function update_external_params!(md::ModelDef, parameters::Dict; update_timesteps = false)
+function update_params!(md::ModelDef, parameters::Dict; update_timesteps = false)
     parameters = Dict(Symbol(k) => v for (k, v) in parameters)
     for (param_name, value) in parameters
-        update_external_param!(md, param_name, value; update_timesteps = update_timesteps)
+        update_param!(md, param_name, value; update_timesteps = update_timesteps)
     end
     nothing
 end

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -275,16 +275,13 @@ function set_external_param!(md::ModelDef, name::Symbol, value::Number; param_di
 end
 
 function set_external_param!(md::ModelDef, name::Symbol, value::Union{AbstractArray, Range, Tuple}; param_dims::Union{Void,Array{Symbol}} = nothing)
-    
-    num_dims = length(param_dims)
 
-    if num_dims in (1, 2) && param_dims[1] == :time   
+    if param_dims[1] == :time   
         value = convert(Array{md.number_type}, value)
-
-        values = get_timestep_array(md, eltype(value), num_dims, value)
-                 
+        num_dims = length(param_dims)
+        values = get_timestep_array(md, eltype(value), num_dims, value)      
     else
-         values = value
+        values = value
     end
 
     set_external_array_param!(md, name, values, param_dims)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -341,7 +341,7 @@ function set_external_scalar_param!(md::ModelDef, name::Symbol, value::Any)
 end
 
 """
-    update_external_param(md::ModelDef, name::Symbol, value; update_timesteps = false)
+    update_external_param!(md::ModelDef, name::Symbol, value; update_timesteps = false)
 
 Update the `value` of an external model parameter in ModelDef `md`, referenced 
 by `name`. Optional boolean argument `update_timesteps` with default value 

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -411,7 +411,7 @@ function _update_array_param!(md::ModelDef, name, value, update_timesteps)
             new_timestep_array = get_timestep_array(md, T, N, value)
             md.external_params[name] = ArrayModelParameter(new_timestep_array, param.dimensions)
         else
-            warn("Cannot update timesteps; parameter $name is not a TimestepArray.")
+            error("Cannot update timesteps; parameter $name is not a TimestepArray.")
             param.values = value
         end
     else

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -232,21 +232,6 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
     nothing
 end
 
-"""
-    update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T
-
-For each (k, v) in the provided `parameters` dictionary, update_external_param! 
-is called to update the external parameter by name k to value v, with optional 
-Boolean argument update_timesteps.
-"""
-function update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T 
-    parameters = Dict(Symbol(k) => v for (k, v) in parameters)
-    for (param_name, value) in parameters
-        update_external_param!(md, param_name, value; update_timesteps = update_timesteps)
-    end
-    nothing
-end
-
 internal_param_conns(md::ModelDef) = md.internal_param_conns
 
 external_param_conns(md::ModelDef) = md.external_param_conns
@@ -353,6 +338,97 @@ Add a scalar type parameter `name` with the value `value` to the model `md`.
 function set_external_scalar_param!(md::ModelDef, name::Symbol, value::Any)
     p = ScalarModelParameter(value)
     set_external_param!(md, name, p)
+end
+
+"""
+    update_external_param(md::ModelDef, name::Symbol, value; update_timesteps = false)
+
+Update the `value` of an external model parameter in ModelDef `md`, referenced 
+by `name`. Optional boolean argument `update_timesteps` with default value 
+`false` indicates whether to update the time keys associated with the parameter 
+values to match the model's time index.
+"""
+function update_external_param!(md::ModelDef, name::Symbol, value; update_timesteps = false)
+    ext_params = md.external_params
+    if ! haskey(ext_params, name)
+        error("Cannot update parameter; $name not found in model's external parameters.")
+    end
+
+    param = ext_params[name]
+
+    if param isa ScalarModelParameter
+        if update_timesteps
+            warn("Cannot update timesteps; parameter $name is a scalar parameter.")
+        end
+        _update_scalar_param!(param, value)
+    else
+        _update_array_param!(md, name, value, update_timesteps)
+    end
+
+end
+
+function _update_scalar_param!(param::ScalarModelParameter, value)
+    if ! (value isa typeof(param.value))
+        try
+            value = convert(typeof(param.value), value)
+        catch e
+            error("Cannot update parameter $name; expected type $(typeof(param.value)) but got $(typeof(value)).")
+        end
+    end
+    param.value = value
+    nothing
+end
+
+function _update_array_param!(md::ModelDef, name, value, update_timesteps)
+    param = md.external_params[name]
+
+    if !(typeof(value) <: AbstractArray)
+        error("Cannot update array parameter $name with a value of type $(typeof(value)).")
+    elseif size(value) != size(param.values)
+        error("Cannot update parameter $name; expected array of size $(size(param.values)) but got array of size $(size(value)).")
+    elseif !(eltype(value) <: eltype(param.values)) 
+        try
+            value = convert(Array{eltype(param.values)}, value)
+        catch e
+            error("Cannot update parameter $name; expected array of type $(eltype(param.values)) but got $(eltype(value)).")
+        end
+    end
+
+    if update_timesteps
+        if param.values isa TimestepArray 
+            T = eltype(value)
+            N = length(size(value))
+            new_timestep_array = get_timestep_array(md, T, N, value)
+            md.external_params[name] = ArrayModelParameter(new_timestep_array, param.dimensions)
+        else
+            warn("Cannot update timesteps; parameter $name is not a TimestepArray.")
+            param.values = value
+        end
+    else
+        if param.values isa TimestepArray
+            param.values.data = value
+        else
+            param.values = value
+        end
+    end
+    nothing
+end
+
+"""
+    update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T
+
+For each (k, v) in the provided `parameters` dictionary, update_external_param! 
+is called to update the external parameter by name k to value v, with optional 
+Boolean argument update_timesteps. Each key k must be a symbol or convert to a
+symbol matching the name of an external parameter that already exists in the 
+model definition.
+"""
+function update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T 
+    parameters = Dict(Symbol(k) => v for (k, v) in parameters)
+    for (param_name, value) in parameters
+        update_external_param!(md, param_name, value; update_timesteps = update_timesteps)
+    end
+    nothing
 end
 
 

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -232,6 +232,14 @@ function set_leftover_params!(md::ModelDef, parameters::Dict{T, Any}) where T
     nothing
 end
 
+function update_external_params!(md::ModelDef, parameters::Dict{T, Any}; update_timesteps = false) where T 
+    parameters = Dict(Symbol(k) => v for (k, v) in parameters)
+    for (param_name, value) in parameters
+        update_external_param!(md, param_name, value; update_timesteps = update_timesteps)
+    end
+    nothing
+end
+
 internal_param_conns(md::ModelDef) = md.internal_param_conns
 
 external_param_conns(md::ModelDef) = md.external_param_conns

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -111,29 +111,29 @@ function set_leftover_params!(m::Model, parameters::Dict{T, Any}) where T
 end
 
 """
-    update_external_param(m::Model, name::Symbol, value; update_timesteps = false)
+    update_param!(m::Model, name::Symbol, value; update_timesteps = false)
 
 Update the `value` of an external model parameter in model `m`, referenced by 
 `name`. Optional boolean argument `update_timesteps` with default value `false` 
 indicates whether to update the time keys associated with the parameter values 
 to match the model's time index.
 """
-function update_external_param!(m::Model, name::Symbol, value; update_timesteps = false)
-    update_external_param!(m.md, name, value, update_timesteps = update_timesteps)
+function update_param!(m::Model, name::Symbol, value; update_timesteps = false)
+    update_param!(m.md, name, value, update_timesteps = update_timesteps)
     decache(m)
 end
 
 """
-    update_external_params!(m::Model, parameters::Dict{T, Any}; update_timesteps = false) where T
+    update_params!(m::Model, parameters::Dict{T, Any}; update_timesteps = false) where T
 
-For each (k, v) in the provided `parameters` dictionary, update_external_param! 
+For each (k, v) in the provided `parameters` dictionary, update_param! 
 is called to update the external parameter by name k to value v, with optional 
 Boolean argument update_timesteps. Each key k must be a symbol or convert to a
 symbol matching the name of an external parameter that already exists in the 
 model definition.
 """
-function update_external_params!(m::Model, parameters::Dict; update_timesteps = false)
-    update_external_params!(m.md, parameters; update_timesteps = update_timesteps)
+function update_params!(m::Model, parameters::Dict; update_timesteps = false)
+    update_params!(m.md, parameters; update_timesteps = update_timesteps)
     decache(m)
 end
 

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -132,7 +132,7 @@ Boolean argument update_timesteps. Each key k must be a symbol or convert to a
 symbol matching the name of an external parameter that already exists in the 
 model definition.
 """
-function update_external_params!(m::Model, parameters::Dict{T, Any}; update_timesteps = false) where T
+function update_external_params!(m::Model, parameters::Dict; update_timesteps = false)
     update_external_params!(m.md, parameters; update_timesteps = update_timesteps)
     decache(m)
 end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -110,6 +110,15 @@ function set_leftover_params!(m::Model, parameters::Dict{T, Any}) where T
     decache(m)
 end
 
+"""
+    update_external_params!(m::Model, parameters::Dict{T, Any}; update_timesteps = false) where T
+
+For each (k, v) in the provided `parameters` dictionary, update_external_param! 
+is called to update the external parameter by name k to value v, with optional 
+Boolean argument update_timesteps. Each key k must be a symbol or convert to a
+symbol matching the name of an external parameter that already exists in the 
+model definition.
+"""
 function update_external_params!(m::Model, parameters::Dict{T, Any}; update_timesteps = false) where T
     update_external_params!(m.md, parameters; update_timesteps = update_timesteps)
     decache(m)
@@ -315,19 +324,28 @@ function Base.run(m::Model; ntimesteps::Int=typemax(Int),
     nothing
 end
 
-#
-# TBD: This function is currently used only in test/test_parametertypes. Is it still needed?
-#
-"""
-    update_external_param(m::Model, name::Symbol, value)
 
-Update the `value` of an external model parameter in model `m`, referenced by `name`.
+"""
+    update_external_param(m::Model, name::Symbol, value; update_timesteps = false)
+
+Update the `value` of an external model parameter in model `m`, referenced by 
+`name`. Optional boolean argument `update_timesteps` with default value `false` 
+indicates whether to update the time keys associated with the parameter values 
+to match the model's time index.
 """
 function update_external_param!(m::Model, name::Symbol, value; update_timesteps = false)
     update_external_param!(m.md, name, value, update_timesteps = update_timesteps)
     decache(m)
 end 
 
+"""
+    update_external_param(md::ModelDef, name::Symbol, value; update_timesteps = false)
+
+Update the `value` of an external model parameter in ModelDef `md`, referenced 
+by `name`. Optional boolean argument `update_timesteps` with default value 
+`false` indicates whether to update the time keys associated with the parameter 
+values to match the model's time index.
+"""
 function update_external_param!(md::ModelDef, name::Symbol, value; update_timesteps = false)
     ext_params = md.external_params
     if ! haskey(ext_params, name)

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -165,6 +165,11 @@ end
 
 # Generic-size Array version of get_timestep_instance()
 function get_timestep_array(md::ModelDef, T, N, value)
+
+	if N == 1 || N == 2
+		return get_timestep_instance(md, T, N, value)
+	end
+
 	if isuniform(md)
         first, stepsize = first_and_step(md)
         return TimestepArray{FixedTimestep{first, stepsize}, T, N}(value)

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -163,6 +163,17 @@ function get_timestep_instance(md::ModelDef, T, num_dims, value)
 	end
 end
 
+# Generic-size Array version of get_timestep_instance()
+function get_timestep_array(md::ModelDef, T, N, value)
+	if isuniform(md)
+        first, stepsize = first_and_step(md)
+        return TimestepArray{FixedTimestep{first, stepsize}, T, N}(value)
+    else
+        TIMES = (time_labels(md)...)
+        return TimestepArray{VariableTimestep{TIMES}, T, N}(value)
+    end
+end
+
 const AnyIndex = Union{Int, Vector{Int}, Tuple, Colon, OrdinalRange}
 
 # TBD: can it be reduced to this?

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -145,30 +145,8 @@ end
 # 3a.  General
 #
 
-function get_timestep_instance(md::ModelDef, T, num_dims, value)
-	if !(num_dims in (1, 2))
-		error("TimeStepVector or TimestepMatrix support only 1 or 2 dimensions, not $num_dims")
-	end
-
-	timestep_array_type = num_dims == 1 ? TimestepVector : TimestepMatrix
-
-	if isuniform(md)
-		first, stepsize = first_and_step(md)
-		return timestep_array_type{FixedTimestep{first, stepsize}, T}(value)
-	else
-
-		times = time_labels(md)		
-		return timestep_array_type{VariableTimestep{(times...)}, T}(value)	
-
-	end
-end
-
-# Generic-size Array version of get_timestep_instance()
+# Get a timestep array of type T with N dimensions. Time labels will match those from the time dimension in md
 function get_timestep_array(md::ModelDef, T, N, value)
-
-	if N == 1 || N == 2
-		return get_timestep_instance(md, T, N, value)
-	end
 
 	if isuniform(md)
         first, stepsize = first_and_step(md)

--- a/test/test_parametertypes.jl
+++ b/test/test_parametertypes.jl
@@ -4,7 +4,7 @@ using Mimi
 using Base.Test
 
 import Mimi: 
-    external_params, update_external_param, TimestepMatrix, TimestepVector, 
+    external_params, update_external_param!, TimestepMatrix, TimestepVector, 
     ArrayModelParameter, ScalarModelParameter, FixedTimestep, reset_compdefs
 
 reset_compdefs()
@@ -84,21 +84,88 @@ extpars = external_params(m)
 @test typeof(extpars[:h].value) == numtype
 
 # test updating parameters
-@test_throws ErrorException update_external_param(m, :a, 5) # expects an array
-@test_throws ErrorException update_external_param(m, :a, ones(101)) # wrong size
-@test_throws ErrorException update_external_param(m, :a, fill("hi", 101, 3)) # wrong type
-update_external_param(m, :a, Array{Int,2}(zeros(101, 3))) # should be able to convert from Int to Float
 
-@test_throws ErrorException update_external_param(m, :d, ones(5)) # wrong type; should be scalar
-update_external_param(m, :d, 5) # should work, will convert to float
+@test_throws ErrorException update_external_param!(m, :a, 5) # expects an array
+@test_throws ErrorException update_external_param!(m, :a, ones(101)) # wrong size
+@test_throws ErrorException update_external_param!(m, :a, fill("hi", 101, 3)) # wrong type
+update_external_param!(m, :a, Array{Int,2}(zeros(101, 3))) # should be able to convert from Int to Float
+
+@test_throws ErrorException update_external_param!(m, :d, ones(5)) # wrong type; should be scalar
+update_external_param!(m, :d, 5) # should work, will convert to float
 @test extpars[:d].value == 5
-@test_throws ErrorException update_external_param(m, :e, 5) # wrong type; should be array
-@test_throws ErrorException update_external_param(m, :e, ones(10)) # wrong size
-update_external_param(m, :e, [4,5,6,7])
+@test_throws ErrorException update_external_param!(m, :e, 5) # wrong type; should be array
+@test_throws ErrorException update_external_param!(m, :e, ones(10)) # wrong size
+update_external_param!(m, :e, [4,5,6,7])
 
 @test length(extpars) == 8
 @test typeof(extpars[:a].values) == TimestepMatrix{FixedTimestep{2000, 1}, numtype}
 @test typeof(extpars[:d].value) == numtype
 @test typeof(extpars[:e].values) == Array{numtype, 1}
+
+
+#------------------------------------------------------------------------------
+# Test updating TimestepArrays with update_external_parameter
+#------------------------------------------------------------------------------
+
+using Mimi
+using Base.Test
+import Mimi: update_external_param!
+@defcomp MyComp2 begin 
+    x=Parameter(index=[time]) 
+    y=Variable(index=[time])
+    function run_timestep(p,v,d,t)
+        v.y[t]=p.x[t]
+    end
+end
+
+# 1. Test with Fixed Timesteps
+
+m = Model()
+set_dimension!(m, :time, 2000:2002)
+add_comp!(m, MyComp2)
+set_param!(m, :MyComp2, :x, [1, 2, 3])
+set_dimension!(m, :time, 2001:2003)
+
+update_external_param!(m, :x, [4, 5, 6], update_timesteps = false)
+x = m.md.external_params[:x]
+@test x.values isa Mimi.TimestepArray{Mimi.FixedTimestep{2000, 1, LAST} where LAST, Float64, 1}
+@test x.values.data == [4., 5., 6.]
+run(m)
+@test m[:MyComp2, :y][1] == 5   # 2001
+@test m[:MyComp2, :y][2] == 6   # 2002
+
+update_external_param!(m, :x, [2, 3, 4], update_timesteps = true)
+x = m.md.external_params[:x]
+@test x.values isa Mimi.TimestepArray{Mimi.FixedTimestep{2001, 1, LAST} where LAST, Float64, 1}
+@test x.values.data == [2., 3., 4.]
+run(m)
+@test m[:MyComp2, :y][1] == 2   # 2001
+@test m[:MyComp2, :y][2] == 3   # 2002
+
+
+# 2. Test with Variable Timesteps
+
+m = Model()
+set_dimension!(m, :time, [2000, 2005, 2020])
+add_comp!(m, MyComp2)
+set_param!(m, :MyComp2, :x, [1, 2, 3])
+set_dimension!(m, :time, [2005, 2020, 2050])
+
+update_external_param!(m, :x, [4, 5, 6], update_timesteps = false)
+x = m.md.external_params[:x]
+@test x.values isa Mimi.TimestepArray{Mimi.VariableTimestep{(2000, 2005, 2020)}, Float64, 1}
+@test x.values.data == [4., 5., 6.]
+run(m)
+@test m[:MyComp2, :y][1] == 5   # 2005
+@test m[:MyComp2, :y][2] == 6   # 2020
+
+update_external_param!(m, :x, [2, 3, 4], update_timesteps = true)
+x = m.md.external_params[:x]
+@test x.values isa Mimi.TimestepArray{Mimi.VariableTimestep{(2005, 2020, 2050)}, Float64, 1}
+@test x.values.data == [2., 3., 4.]
+run(m)
+@test m[:MyComp2, :y][1] == 2   # 2005
+@test m[:MyComp2, :y][2] == 3   # 2020
+
 
 end #module

--- a/test/test_parametertypes.jl
+++ b/test/test_parametertypes.jl
@@ -84,15 +84,16 @@ extpars = external_params(m)
 @test typeof(extpars[:h].value) == numtype
 
 # test updating parameters
-@test_throws ErrorException update_external_param(m, :a, 5) #expects an array
-@test_throws ErrorException update_external_param(m, :a, ones(101)) #wrong size
-@test_throws ErrorException update_external_param(m, :a, fill("hi", 101, 3)) #wrong type
-update_external_param(m, :a, zeros(101,3))
+@test_throws ErrorException update_external_param(m, :a, 5) # expects an array
+@test_throws ErrorException update_external_param(m, :a, ones(101)) # wrong size
+@test_throws ErrorException update_external_param(m, :a, fill("hi", 101, 3)) # wrong type
+update_external_param(m, :a, Array{Int,2}(zeros(101, 3))) # should be able to convert from Int to Float
 
-@test_throws ErrorException update_external_param(m, :d, ones(5)) #wrong type; should be scalar
+@test_throws ErrorException update_external_param(m, :d, ones(5)) # wrong type; should be scalar
 update_external_param(m, :d, 5) # should work, will convert to float
-@test_throws ErrorException update_external_param(m, :e, 5) #wrong type; should be array
-@test_throws ErrorException update_external_param(m, :e, ones(10)) #wrong size
+@test extpars[:d].value == 5
+@test_throws ErrorException update_external_param(m, :e, 5) # wrong type; should be array
+@test_throws ErrorException update_external_param(m, :e, ones(10)) # wrong size
 update_external_param(m, :e, [4,5,6,7])
 
 @test length(extpars) == 8

--- a/test/test_parametertypes.jl
+++ b/test/test_parametertypes.jl
@@ -85,17 +85,17 @@ extpars = external_params(m)
 
 # test updating parameters
 
-@test_throws ErrorException update_external_param!(m, :a, 5) # expects an array
-@test_throws ErrorException update_external_param!(m, :a, ones(101)) # wrong size
-@test_throws ErrorException update_external_param!(m, :a, fill("hi", 101, 3)) # wrong type
-update_external_param!(m, :a, Array{Int,2}(zeros(101, 3))) # should be able to convert from Int to Float
+@test_throws ErrorException update_param!(m, :a, 5) # expects an array
+@test_throws ErrorException update_param!(m, :a, ones(101)) # wrong size
+@test_throws ErrorException update_param!(m, :a, fill("hi", 101, 3)) # wrong type
+update_param!(m, :a, Array{Int,2}(zeros(101, 3))) # should be able to convert from Int to Float
 
-@test_throws ErrorException update_external_param!(m, :d, ones(5)) # wrong type; should be scalar
-update_external_param!(m, :d, 5) # should work, will convert to float
+@test_throws ErrorException update_param!(m, :d, ones(5)) # wrong type; should be scalar
+update_param!(m, :d, 5) # should work, will convert to float
 @test extpars[:d].value == 5
-@test_throws ErrorException update_external_param!(m, :e, 5) # wrong type; should be array
-@test_throws ErrorException update_external_param!(m, :e, ones(10)) # wrong size
-update_external_param!(m, :e, [4,5,6,7])
+@test_throws ErrorException update_param!(m, :e, 5) # wrong type; should be array
+@test_throws ErrorException update_param!(m, :e, ones(10)) # wrong size
+update_param!(m, :e, [4,5,6,7])
 
 @test length(extpars) == 8
 @test typeof(extpars[:a].values) == TimestepMatrix{FixedTimestep{2000, 1}, numtype}
@@ -104,7 +104,7 @@ update_external_param!(m, :e, [4,5,6,7])
 
 
 #------------------------------------------------------------------------------
-# Test updating TimestepArrays with update_external_param!
+# Test updating TimestepArrays with update_param!
 #------------------------------------------------------------------------------
 
 @defcomp MyComp2 begin 
@@ -123,7 +123,7 @@ add_comp!(m, MyComp2)
 set_param!(m, :MyComp2, :x, [1, 2, 3])
 set_dimension!(m, :time, 2001:2003)
 
-update_external_param!(m, :x, [4, 5, 6], update_timesteps = false)
+update_param!(m, :x, [4, 5, 6], update_timesteps = false)
 x = m.md.external_params[:x]
 @test x.values isa Mimi.TimestepArray{Mimi.FixedTimestep{2000, 1, LAST} where LAST, Float64, 1}
 @test x.values.data == [4., 5., 6.]
@@ -131,7 +131,7 @@ run(m)
 @test m[:MyComp2, :y][1] == 5   # 2001
 @test m[:MyComp2, :y][2] == 6   # 2002
 
-update_external_param!(m, :x, [2, 3, 4], update_timesteps = true)
+update_param!(m, :x, [2, 3, 4], update_timesteps = true)
 x = m.md.external_params[:x]
 @test x.values isa Mimi.TimestepArray{Mimi.FixedTimestep{2001, 1, LAST} where LAST, Float64, 1}
 @test x.values.data == [2., 3., 4.]
@@ -148,7 +148,7 @@ add_comp!(m, MyComp2)
 set_param!(m, :MyComp2, :x, [1, 2, 3])
 set_dimension!(m, :time, [2005, 2020, 2050])
 
-update_external_param!(m, :x, [4, 5, 6], update_timesteps = false)
+update_param!(m, :x, [4, 5, 6], update_timesteps = false)
 x = m.md.external_params[:x]
 @test x.values isa Mimi.TimestepArray{Mimi.VariableTimestep{(2000, 2005, 2020)}, Float64, 1}
 @test x.values.data == [4., 5., 6.]
@@ -156,7 +156,7 @@ run(m)
 @test m[:MyComp2, :y][1] == 5   # 2005
 @test m[:MyComp2, :y][2] == 6   # 2020
 
-update_external_param!(m, :x, [2, 3, 4], update_timesteps = true)
+update_param!(m, :x, [2, 3, 4], update_timesteps = true)
 x = m.md.external_params[:x]
 @test x.values isa Mimi.TimestepArray{Mimi.VariableTimestep{(2005, 2020, 2050)}, Float64, 1}
 @test x.values.data == [2., 3., 4.]
@@ -172,7 +172,7 @@ set_dimension!(m, :time, [2000, 2005, 2020])
 add_comp!(m, MyComp2)
 set_param!(m, :MyComp2, :x, [1, 2, 3])
 set_dimension!(m, :time, [2005, 2020, 2050])
-update_external_params!(m, Dict(:x=>[2, 3, 4]), update_timesteps = true)
+update_params!(m, Dict(:x=>[2, 3, 4]), update_timesteps = true)
 x = m.md.external_params[:x]
 @test x.values isa Mimi.TimestepArray{Mimi.VariableTimestep{(2005, 2020, 2050)}, Float64, 1}
 @test x.values.data == [2., 3., 4.]

--- a/test/test_parametertypes.jl
+++ b/test/test_parametertypes.jl
@@ -180,4 +180,23 @@ run(m)
 @test m[:MyComp2, :y][1] == 2   # 2005
 @test m[:MyComp2, :y][2] == 3   # 2020
 
+
+# 4. Test updating the time index to a different length
+
+m = Model()
+set_dimension!(m, :time, 2000:2002)     # length 3
+add_comp!(m, MyComp2)
+set_param!(m, :MyComp2, :x, [1, 2, 3])
+set_dimension!(m, :time, 1999:2003)     # length 5
+
+update_param!(m, :x, [2, 3, 4, 5, 6], update_timesteps = true)
+x = m.md.external_params[:x]
+@test x.values isa Mimi.TimestepArray{Mimi.FixedTimestep{1999, 1, LAST} where LAST, Float64, 1}
+@test x.values.data == [2., 3., 4., 5., 6.]
+
+run(m)
+@test m[:MyComp2, :y][1] == 3.  # 2000
+@test m[:MyComp2, :y][2] == 4.  # 2001
+@test m[:MyComp2, :y][3] == 5.  # 2002
+
 end #module

--- a/test/test_timesteps.jl
+++ b/test/test_timesteps.jl
@@ -6,7 +6,7 @@ using Base.Test
 import Mimi:
     AbstractTimestep, FixedTimestep, VariableTimestep, TimestepVector, 
     TimestepMatrix, TimestepArray, next_timestep, hasvalue, is_first, is_last, 
-    gettime, getproperty, Clock, time_index, get_timestep_instance, reset_compdefs
+    gettime, getproperty, Clock, time_index, get_timestep_array, reset_compdefs
 
 reset_compdefs()
 
@@ -118,7 +118,7 @@ for i in 6:11
 end
 
 ##################################################
-#  test get_timestep_instance
+#  test get_timestep_array
 ##################################################
 m = Model()
 
@@ -128,19 +128,18 @@ set_dimension!(m, :time, 2000:2009)
 vector = ones(5)
 matrix = ones(3,2)
 
-t_vector= get_timestep_instance(m.md, Float64, 1, vector)
-t_matrix = get_timestep_instance(m.md, Float64, 2, matrix)
+t_vector= get_timestep_array(m.md, Float64, 1, vector)
+t_matrix = get_timestep_array(m.md, Float64, 2, matrix)
 
 @test typeof(t_vector) <: TimestepVector
 @test typeof(t_matrix) <: TimestepMatrix
 
-@test_throws ErrorException get_timestep_instance(m.md, Float64, 3, vector) #too many dims
 
 #try with variable timestep
 set_dimension!(m, :time, [2000:1:2004; 2005:2:2016])
 
-t_vector= get_timestep_instance(m.md, Float64, 1, vector)
-t_matrix = get_timestep_instance(m.md, Float64, 2, matrix)
+t_vector= get_timestep_array(m.md, Float64, 1, vector)
+t_matrix = get_timestep_array(m.md, Float64, 2, matrix)
 
 @test typeof(t_vector) <: TimestepVector
 @test typeof(t_matrix) <: TimestepMatrix


### PR DESCRIPTION
new functionality:

if `update_timesteps == true`:
- ERROR if it's a scalar parameter (cannot update timesteps for scalars)
- ERROR if the existing param is an Array but not a timestep array
- ERROR if the new values are the wrong size, or a different data type that can't be converted

In the case of multiple updates from a dictionary using `update_params!` if `update_timesteps==true`, then it will not error in the scalar or non-timestep array cases, allowing the user to have a dictionary of all types of parameters.

questions:
- [x] in the case of update_timesteps == true, should we instead be checking the size of the new data against the model's new time index, rather than against the old value's size?
- [x] do we like how explicit the name `update_external_param!` is, or should we make it more consistent and call it `update_param!` instead?
- [x] - I put the calls to type Model in the src/core/model.jl file, and the calls to type ModelDef and the internal supporting functions in src/core/connections.jl. Does this organization make sense?
- [x] - for now i've exported both `update_external_param!` (for a single parameter) and `update_external_params!` (for multiple parameter update from a dictionary). is this okay?
- [x] - I added a new function `get_timestep_array` very similar to the already existing function `get_timestep_instance` that generates a generic-size array, instead of a vector or matrix. Should this function be used instead everywhere? or do we want to keep using vectors and matrices for 1 and 2 dimensional cases?