### PR TITLE
WIP replace_comp!

### DIFF
--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -539,11 +539,16 @@ end
 """
     replace_comp!(md::ModelDef, comp_id::ComponentId, comp_name::Symbol=comp_id.comp_name;
         first::VoidInt=nothing, last::VoidInt=nothing,
-        before::VoidSymbol=nothing, after::VoidSymbol=nothing)
+        before::VoidSymbol=nothing, after::VoidSymbol=nothing,
+        reconnect::Bool=true)
 
-Replace the component with name `comp_name` in model `md`  with the component
-`comp_id` using the same name.  The component is added at the end of 
-the list unless one of the keywords, `first`, `last`, `before`, `after`.
+Replace the component with name `comp_name` in model definition `md` with the 
+component `comp_id` using the same name. The component is added in the same 
+position as the old component, unless one of the keywords `before` or `after` 
+is specified. The component is added with the same first and last values, 
+unless the keywords `first` or `last` are specified. Optional boolean argument 
+`reconnect` with default value `true` indicates whether the existing parameter 
+connections should be maintained in the new component.
 """
 function replace_comp!(md::ModelDef, comp_id::ComponentId, comp_name::Symbol=comp_id.comp_name;
                            first::VoidInt=nothing, last::VoidInt=nothing,

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -563,7 +563,7 @@ function replace_comp!(md::ModelDef, comp_id::ComponentId, comp_name::Symbol=com
 
     # Get original first and last if new run period not specified
     first = first == nothing ? md.comp_defs[comp_name].first : first
-    last = last == nothing? md.comp_defs[comp_name].last : last
+    last = last == nothing ? md.comp_defs[comp_name].last : last
 
     if reconnect
         # Assert that new component definition has same parameters and variables needed for the connections
@@ -615,10 +615,11 @@ function replace_comp!(md::ModelDef, comp_id::ComponentId, comp_name::Symbol=com
         end
         filter!(epc -> !(epc in remove), md.external_param_conns) 
 
-        # Delete old component from comp_defs, leaving the existing parameter connections 
+        # Delete the old component from comp_defs, leaving the existing parameter connections 
         delete!(md.comp_defs, comp_name)      
     else
-        delete!(md, comp_name)  # Built-in Mimi delete function deletes all internal and external parameter connections as well
+        # Delete the old component and all its internal and external parameter connections
+        delete!(md, comp_name)  
     end
 
     # Re-add

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -135,8 +135,9 @@ Replace the component with name `comp_name` in model `md`  with the component
 """
 function replace_comp!(m::Model, comp_id::ComponentId, comp_name::Symbol=comp_id.comp_name;
                            first::VoidSymbol=nothing, last::VoidSymbol=nothing,
-                           before::VoidSymbol=nothing, after::VoidSymbol=nothing)
-    replace_comp!(m.md, comp_id, comp_name; first=first, last=last, before=before, after=after)
+                           before::VoidSymbol=nothing, after::VoidSymbol=nothing,
+                           reconnect=true)
+    replace_comp!(m.md, comp_id, comp_name; first=first, last=last, before=before, after=after, reconnect = reconnect)
     decache(m)
     return ComponentReference(m, comp_name)
 end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -137,7 +137,7 @@ function replace_comp!(m::Model, comp_id::ComponentId, comp_name::Symbol=comp_id
                            first::VoidSymbol=nothing, last::VoidSymbol=nothing,
                            before::VoidSymbol=nothing, after::VoidSymbol=nothing,
                            reconnect=true)
-    replace_comp!(m.md, comp_id, comp_name; first=first, last=last, before=before, after=after, reconnect = reconnect)
+    replace_comp!(m.md, comp_id, comp_name; first=first, last=last, before=before, after=after, reconnect=reconnect)
     decache(m)
     return ComponentReference(m, comp_name)
 end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -128,15 +128,21 @@ end
 """
     replace_comp!(m::Model, comp_id::ComponentId, comp_name::Symbol=comp_id.comp_name;
         first::VoidSymbol=nothing, last::VoidSymbol=nothing,
-        before::VoidSymbol=nothing, after::VoidSymbol=nothing)
+        before::VoidSymbol=nothing, after::VoidSymbol=nothing,
+        reconnect::Bool=true)
         
-Replace the component with name `comp_name` in model `md`  with the component
-`comp_id` using the same name.  
+Replace the component with name `comp_name` in model `m` with the component
+`comp_id` using the same name.  The component is added in the same position as 
+the old component, unless one of the keywords `before` or `after` is specified.
+The component is added with the same first and last values, unless the keywords 
+`first` or `last` are specified. Optional boolean argument `reconnect` with 
+default value `true` indicates whether the existing parameter connections 
+should be maintained in the new component.  
 """
 function replace_comp!(m::Model, comp_id::ComponentId, comp_name::Symbol=comp_id.comp_name;
                            first::VoidSymbol=nothing, last::VoidSymbol=nothing,
                            before::VoidSymbol=nothing, after::VoidSymbol=nothing,
-                           reconnect=true)
+                           reconnect::Bool=true)
     replace_comp!(m.md, comp_id, comp_name; first=first, last=last, before=before, after=after, reconnect=reconnect)
     decache(m)
     return ComponentReference(m, comp_name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,9 @@ end
     @info("test_model_structure_variabletimestep.jl") 
     include("test_model_structure_variabletimestep.jl")
 
+    @info("test_replace_comp.jl")
+    include("test_replace_comp.jl")
+
     @info("test_tools.jl")
     include("test_tools.jl")
 

--- a/test/test_replace_comp.jl
+++ b/test/test_replace_comp.jl
@@ -109,6 +109,7 @@ set_param!(m, :X, :x, zeros(6))                         # Set external parameter
 
 
 # 7. Test component name that doesn't exist
+
 m = Model()
 set_dimension!(m, :time, 2000:2005)
 add_comp!(m, X)

--- a/test/test_replace_comp.jl
+++ b/test/test_replace_comp.jl
@@ -115,4 +115,17 @@ add_comp!(m, X)
 @test_throws ErrorException replace_comp!(m, X_repl, :Z)    # Component Z does not exist in the model, cannot be replaced
 
 
+# 8. Test original postion placement functionality
+
+m = Model()
+set_dimension!(m, :time, 2000:2005)
+add_comp!(m, X, :c1)    
+add_comp!(m, X, :c2)
+add_comp!(m, X, :c3)
+replace_comp!(m, X_repl, :c3)   # test replacing the last component
+@test collect(values(m.md.comp_defs))[3].comp_id.comp_name == :X_repl
+replace_comp!(m, X_repl, :c2)        # test replacing not the last one
+@test collect(values(m.md.comp_defs))[2].comp_id.comp_name == :X_repl
+
+
 end # module

--- a/test/test_replace_comp.jl
+++ b/test/test_replace_comp.jl
@@ -1,0 +1,111 @@
+module TestReplaceComp
+
+using Base.Test
+using Mimi
+
+
+@defcomp X begin    
+    x = Parameter(index = [time])
+    y = Variable(index = [time])
+    function run_timestep(p, v, d, t)
+        v.y[t] = 1
+    end
+end 
+
+@defcomp X_repl begin
+    x = Parameter(index = [time])
+    y = Variable(index = [time])
+    function run_timestep(p, v, d, t)
+        v.y[t] = 2
+    end
+end
+
+@defcomp bad1 begin
+    x = Parameter()                 # parameter has same name as in component X, but different dimensions
+    y = Variable(index = [time])
+end
+
+@defcomp bad2 begin
+    x = Parameter(index = [time])
+    z = Variable(index = [time])    # different variable name
+end
+
+@defcomp bad3 begin
+    z = Parameter()                 # external parameter with different dimensions
+    y = Variable(index = [time])
+end
+
+@defcomp bad4 begin
+    x::Symbol = Parameter(index = [time])   # different datatype
+    y = Variable()                          # different variable dimensions
+end
+
+
+
+# 1. Test scenario where the replacement works
+
+m = Model()
+set_dimension!(m, :time, 2000:2005)
+add_comp!(m, X)
+set_param!(m, :X, :x, zeros(6))
+replace_comp!(m, X_repl, :X)
+run(m)
+@test length(components(m)) == 1
+@test m[:X, :y] == 2 * ones(6) 
+
+
+# 2. Test bad internal incoming parameter
+
+m = Model()
+set_dimension!(m, :time, 2000:2005)
+add_comp!(m, X, :first)
+add_comp!(m, X, :second)
+connect_param!(m, :second => :x, :first => :y)
+@test_throws ErrorException replace_comp!(m, bad1, :second) 
+replace_comp!(m, bad1, :second, reconnect = false)  # Works without reconnecting
+@test m.md.comp_defs[:second].comp_id.comp_name == :bad1
+
+
+# 3. Test bad internal outgoing variable
+
+m = Model()
+set_dimension!(m, :time, 2000:2005)
+add_comp!(m, X, :first)
+add_comp!(m, X, :second)
+connect_param!(m, :second => :x, :first => :y)
+@test_throws ErrorException replace_comp!(m, bad2, :first) 
+replace_comp!(m, bad2, :first, reconnect = false) 
+@test m.md.comp_defs[:first].comp_id.comp_name == :bad2
+
+
+# 4. Test bad external parameter name
+
+m = Model()
+set_dimension!(m, :time, 2000:2005)
+add_comp!(m, X)
+set_param!(m, :X, :x, zeros(6))
+replace_comp!(m, bad3, :X)                          # Warns that there is no parameter by the same name
+@test m.md.comp_defs[:X].comp_id.comp_name == :bad3 # still replaces
+@test length(m.md.external_param_conns) == 0        # the external paramter connection is gone
+@test length(m.md.external_params) == 1             # the external parameter still exists
+
+
+# 5. Test bad external parameter dimensions
+
+m = Model()
+set_dimension!(m, :time, 2000:2005)
+add_comp!(m, X)
+set_param!(m, :X, :x, zeros(6))
+@test_throws ErrorException replace_comp!(m, bad1, :X)
+
+
+# 6. Test bad external parameter datatype
+
+m = Model()
+set_dimension!(m, :time, 2000:2005)
+add_comp!(m, X)
+set_param!(m, :X, :x, zeros(6))
+@test_throws ErrorException replace_comp!(m, bad4, :X)
+
+
+end # module


### PR DESCRIPTION
Address issue #289 , with optional bool argument `reconnect`.

If reconnect==false, same behavior as before.

If reconnect==true, then replace_comp! only deletes the old component from md.comp_defs, and does not delete the internal or external parameter connections that the component belongs to.

It performs the following checks (in the case of reconnect==true):
- it checks that the new component definition has any parameter names that are present in any incoming internal parameter connections, and checks that the dimensions and datatype are the same. Question: should all of the datum fields need to match? Like units and description?
- it checks that the new component definition has any variable names that are present in any outgoing internal parameter connections, and checks that the dimensions and datatype are the same.
- it checks if the new component has the parameter names that are present in any external parameter connections. If it's missing a parameter, it just gives a warning and removes the external parameter connection (should this error?). But if it has the parameter and has different dimensions or datatypes, then it errors

