### PR TITLE
add_comp! check for time dim

### DIFF
--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -475,6 +475,12 @@ differs from that in the `comp_def`, a copy of `comp_def` is made and assigned t
 function add_comp!(md::ModelDef, comp_def::ComponentDef, comp_name::Symbol;
                       first::VoidInt=nothing, last::VoidInt=nothing, 
                       before::VoidSymbol=nothing, after::VoidSymbol=nothing)
+
+    # check that a time dimension has been set
+    if !haskey(dimensions(md), :time)
+        error("Cannot add component to model without first setting time dimension.")
+    end
+    
     # check that first and last are within the model's time index range
     time_index = dim_keys(md, :time)
 

--- a/test/test_model_structure.jl
+++ b/test/test_model_structure.jl
@@ -44,6 +44,10 @@ end
 end
 
 m = Model()
+
+# make sure you can't add a component before setting time dimension
+@test_throws ErrorException add_comp!(m, A)
+
 set_dimension!(m, :time, 2015:5:2100)
 
 add_comp!(m, A)


### PR DESCRIPTION
Add a check and corresponding error if `add_comp!` is called before a time index is set.  Per issue #304 