### PR TITLE
Make SampleStores for EmpiricalDistributions during generate_trial

### DIFF
--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -204,9 +204,9 @@ function Base.rand!(mcs::MonteCarloSimulation)
     rvdict = mcs.rvdict
     trials = mcs.trials
 
-    for rv in mcs.dist_rvs
+    for (name, rv) in mcs.rvdict
         values = rand(rv.dist, trials)
-        rvdict[rv.name] = RandomVariable(rv.name, SampleStore(values))
+        rvdict[name] = RandomVariable(name, SampleStore(values))
     end
 end
 

--- a/test/mcs/test_empirical.jl
+++ b/test/mcs/test_empirical.jl
@@ -34,3 +34,65 @@ expected = [1.47, 1.92, 2.33, 3.01, 4.16, 5.85, 9.16]
 println("quantiles: $q\n expected: $expected")
 
 @test isapprox(q, expected, atol=0.01)
+
+
+# Test that the EmpiricalDistribution gets saved as a SampleStore and values 
+# get re-used across multiple scenarios
+
+num_scenarios = 4
+num_trials = 5
+output_dir = "./out/"
+
+store = zeros(num_scenarios, num_trials)
+
+_values = collect(1:10)
+_probs = 0.1 * ones(10)
+
+mcs_test = @defmcs begin
+    p = EmpiricalDistribution(_values, _probs)
+end 
+
+@defcomp test begin
+    p = Parameter(default = 5)
+    function run_timestep(p, v, d, t) end
+end
+
+scenario_args = [
+    :num => collect(1:num_scenarios)
+]
+
+function scenario_func(mcs::MonteCarloSimulation, tup::Tuple)
+    nothing
+end
+
+function post_trial_func(mcs::MonteCarloSimulation, trialnum::Int, ntimesteps::Int, tup::Tuple)
+    m, = mcs.models
+    scenario_num, = tup
+    store[scenario_num, trialnum] = m[:test, :p]
+end
+
+m = Model()
+set_dimension!(m, :time, 2000:2001)
+add_comp!(m, test)
+set_model!(mcs_test, m)
+
+generate_trials!(mcs_test, num_trials; filename = "$output_dir/trials.csv", sampling = RANDOM)
+
+run_mcs(mcs_test, num_trials; 
+    output_dir = output_dir,
+    scenario_args = scenario_args,
+    scenario_func = scenario_func, 
+    post_trial_func = post_trial_func
+    )
+
+for rv in values(mcs_test.rvdict)
+    @test rv.dist isa Mimi.SampleStore
+end
+
+for i = 1:num_scenarios
+    @test store[i, :] == store[1, :]
+end
+
+rm(output_dir, recursive = true)
+
+# TODO: Also should test in the case of sampling = LHS, which would currently error


### PR DESCRIPTION
address issue #312 
either by make the rand! function loop over everything in the rvdict (instead of just the dist_rv list), OR we need to make EmpricialDistributions part of the dist_rv list

TODO: add tests for whichever functionality we choose