### PR TITLE
Enable automatic storage of EmpiricalDistribution values

### DIFF
--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -108,7 +108,7 @@ mutable struct MonteCarloSimulation
     translist::Vector{TransformSpec}
     corrlist::Vector{CorrelationSpec}
     savelist::Vector{Tuple{Symbol, Symbol}}
-    dist_rvs::Vector{RandomVariable{<: Distribution}}
+    dist_rvs::Vector{RandomVariable}
     nt_type::Any                    # a generated NamedTuple type to hold data for a single trial
     models::Vector{Model}
     results::Vector{Dict{Tuple, DataFrame}}
@@ -125,7 +125,7 @@ mutable struct MonteCarloSimulation
         self.translist = translist
         self.corrlist = corrlist
         self.savelist = savelist
-        self.dist_rvs = [rv for rv in rvlist if rv.dist isa Distribution]
+        self.dist_rvs = [rv for rv in rvlist]
         self.nt_type = NamedTuples.make_tuple(collect(keys(self.rvdict)))
 
         # These are parallel arrays; each model has a corresponding results dict

--- a/test/mcs/test_empirical.jl
+++ b/test/mcs/test_empirical.jl
@@ -34,3 +34,65 @@ expected = [1.47, 1.92, 2.33, 3.01, 4.16, 5.85, 9.16]
 println("quantiles: $q\n expected: $expected")
 
 @test isapprox(q, expected, atol=0.01)
+
+
+# Test that the EmpiricalDistribution gets saved as a SampleStore and values 
+# get re-used across multiple scenarios
+
+num_scenarios = 4
+num_trials = 5
+output_dir = "./out/"
+
+results = zeros(num_scenarios, num_trials)
+
+_values = collect(1:10)
+_probs = 0.1 * ones(10)
+
+mcs_test = @defmcs begin
+    p = EmpiricalDistribution(_values, _probs)
+end 
+
+@defcomp test begin
+    p = Parameter(default = 5)
+    function run_timestep(p, v, d, t) end
+end
+
+scenario_args = [
+    :num => collect(1:num_scenarios)
+]
+
+function scenario_func(mcs::MonteCarloSimulation, tup::Tuple)
+    nothing
+end
+
+function post_trial_func(mcs::MonteCarloSimulation, trialnum::Int, ntimesteps::Int, tup::Tuple)
+    m, = mcs.models
+    scenario_num, = tup
+    results[scenario_num, trialnum] = m[:test, :p]
+end
+
+m = Model()
+set_dimension!(m, :time, 2000:2001)
+add_comp!(m, test)
+set_model!(mcs_test, m)
+
+generate_trials!(mcs_test, num_trials; filename = "$output_dir/trials.csv", sampling = RANDOM)
+
+run_mcs(mcs_test, num_trials; 
+    output_dir = output_dir,
+    scenario_args = scenario_args,
+    scenario_func = scenario_func, 
+    post_trial_func = post_trial_func
+    )
+
+for rv in values(mcs_test.rvdict)
+    @test rv.dist isa Mimi.SampleStore
+end
+
+for i = 1:num_scenarios
+    @test results[i, :] == results[1, :]
+end
+
+rm(output_dir, recursive = true)
+
+# TODO: Also should test in the case of sampling = LHS, which would currently error


### PR DESCRIPTION
I removed the type restrictions on `dist_rvs` and this seems to have solved the original problem. Not sure we have enough tests to verify that it doesn't create other problems...

Issue #312 