### PR TITLE
WIP generate_trials! changes

### DIFF
--- a/docs/src/internals/montecarlo.md
+++ b/docs/src/internals/montecarlo.md
@@ -49,16 +49,18 @@ The `generate_trials!` function can be used to pre-generate data for the given n
 
 ```
 generate_trials!(mcs::MonteCarloSimulation, trials::Int; 
-                 filename::String="", sampling::SamplingOptions=LHS)
+                 filename::String="", sampling::SamplingOptions=RANDOM)
 ```
+
+If the `mcs` parameter has multiple scenarios and the `scenario_loop` placement is set to `OUTER`, this function must be called if the user wants to ensure the same trial data be used in each scenario. If this function is not called, new trial data will be generated for each scenario. 
 
 The `sampling` parameter is of type `SamplingOptions`, an `enum` with two values, `LHS`, and `RANDOM`. Latin Hypercube sampling divides the distribution into equally-spaced quantiles, obtains values at those quantiles, and then shuffles the values. The result is better representation of the tails of the distribution with fewer samples than would be required for purely random sampling.
 
 Note that in the current implementation, rank correlation between parameters is supported only for the `LHS` option.
 
-Also note that if the `filename` argument is used, all random variable draws are made prior to running the model(s) and saved to the given filename. Internally, any `Distribution` instance is converted to a `SampleStore` and the values are subsequently returned in the order generated when `rand!` is called.
+Also note that if the `filename` argument is used, all random variable draws are saved to the given filename. Internally, any `Distribution` instance is converted to a `SampleStore` and the values are subsequently returned in the order generated when `rand!` is called.
 
-If this function is not called prior to calling `run_mcs`, Latin Hypercube sampling is used for all distributions and trial data are not saved.
+If this function is not called prior to calling `run_mcs`, random sampling is used for all distributions and trial data are not saved.
 
 ## Assigning distributions
 

--- a/src/mcs/lhs.jl
+++ b/src/mcs/lhs.jl
@@ -113,7 +113,7 @@ skip: (list of params)) Parameters to process later because they are
 
 Returns DataFrame with `trials` rows of values for the `rvlist`.
 """
-function lhs(rvlist::Vector{RandomVariable}, trials::Int; 
+function lhs(rvlist::Vector{RandomVariable{<: Distribution}}, trials::Int; 
              corrmatrix::Union{Matrix{Float64},Void}=nothing,
              asDataFrame::Bool=true)
 
@@ -144,20 +144,15 @@ function lhs!(mcs::MonteCarloSimulation; corrmatrix::Union{Matrix{Float64},Void}
     trials = mcs.trials
     rvdict = mcs.rvdict
     num_rvs = length(rvdict)
-    rvlist = collect(values(rvdict))
+    rvlist = mcs.dist_rvs
 
     samples = lhs(rvlist, mcs.trials, corrmatrix=corrmatrix, asDataFrame=false)
 
     for (i, rv) in enumerate(rvlist)
         dist = rv.dist
-        
-        # We check when computing the correlation matrix that we aren't trying
-        # to correlate SampleStores, thus we ignore them in this loop.
-        if dist isa Distribution
-            name = rv.name
-            values = samples[:, i]
-            rvdict[name] = RandomVariable(name, SampleStore(values, dist=dist))
-        end
+        name = rv.name
+        values = samples[:, i]
+        rvdict[name] = RandomVariable(name, SampleStore(values))
     end
     return nothing
 end

--- a/src/mcs/lhs.jl
+++ b/src/mcs/lhs.jl
@@ -113,7 +113,7 @@ skip: (list of params)) Parameters to process later because they are
 
 Returns DataFrame with `trials` rows of values for the `rvlist`.
 """
-function lhs(rvlist::Vector{RandomVariable{<: Distribution}}, trials::Int; 
+function lhs(rvlist::Vector{RandomVariable}, trials::Int; 
              corrmatrix::Union{Matrix{Float64},Void}=nothing,
              asDataFrame::Bool=true)
 

--- a/src/mcs/mcs_types.jl
+++ b/src/mcs/mcs_types.jl
@@ -34,10 +34,9 @@ distribution(rv::RandomVariable) = rv.dist
 mutable struct SampleStore{T}
     values::Vector{T}   # generally Int or Float64
     idx::Int            # index of next value to return
-    dist::Union{Void, Distribution}
 
-    function SampleStore(values::Vector{T}; dist::Union{Void, Distribution}=nothing) where T
-        return new{T}(values, 1, dist)
+    function SampleStore(values::Vector{T}) where T
+        return new{T}(values, 1)
     end
 end
 

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -202,16 +202,8 @@ function Base.rand!(mcs::MonteCarloSimulation)
     trials = mcs.trials
 
     for rv in mcs.dist_rvs
-        dist = distribution(rv)
-        if dist isa SampleStore
-            dist = distribution(dist) # get the original distribution
-            if dist == nothing
-                reset(dist)           # restart with idx=1  
-                continue              # reuse loaded values
-            end
-        end
-        values = rand(dist, trials)
-        rvdict[rv.name] = RandomVariable(rv.name, SampleStore(values, dist=dist))
+        values = rand(rv.dist, trials)
+        rvdict[rv.name] = RandomVariable(rv.name, SampleStore(values))
     end
 end
 

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -162,11 +162,12 @@ end
 
 """
     generate_trials!(mcs::MonteCarloSimulation, trials::Int; 
-                     filename::String="", sampling::SamplingOptions)
+                     filename::String="", sampling::SamplingOptions=RANDOM)
 
 Generate the given number of trials for the given MonteCarloSimulation instance. 
-Call this before running the MCS to enable saving of inputs to to choose a sampling 
-method other than LHS. (Currently, only LHS and RANDOM are possible.)
+Call this before running the MCS to pre-generate data to be used by all 
+scenarios. Also enables saving of inputs or choosing a sampling method other 
+than RANDOM. (Currently, only LHS and RANDOM are possible.)
 """
 function generate_trials!(mcs::MonteCarloSimulation, trials::Int; 
                           filename::String="",
@@ -175,11 +176,7 @@ function generate_trials!(mcs::MonteCarloSimulation, trials::Int;
 
     if sampling == LHS
         corrmatrix = correlation_matrix(mcs)
-        rvlist = mcs.dist_rvs
-
-        # update the dict in mcs
         lhs!(mcs, corrmatrix=corrmatrix)
-
     else    # sampling == RANDOM
         rand!(mcs)
     end

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -175,7 +175,7 @@ function generate_trials!(mcs::MonteCarloSimulation, trials::Int;
 
     if sampling == LHS
         corrmatrix = correlation_matrix(mcs)
-        rvlist = collect(values(mcs.rvdict))
+        rvlist = mcs.dist_rvs
 
         # update the dict in mcs
         lhs!(mcs, corrmatrix=corrmatrix)

--- a/test/mcs/test_defmcs.jl
+++ b/test/mcs/test_defmcs.jl
@@ -175,10 +175,23 @@ run_mcs(mcs, N;
 
 N = 1000
 
+# Test new values generated for RANDOM sampling
+
 generate_trials!(mcs, N, sampling=RANDOM)
 trial1 = copy(mcs.rvdict[:name1].dist.values)
 
 generate_trials!(mcs, N, sampling=RANDOM)
+trial2 = copy(mcs.rvdict[:name1].dist.values)
+
+@test length(trial1) == length(trial2)
+@test trial1 != trial2
+
+# Test new values generated for LHS sampling
+
+generate_trials!(mcs, N, sampling=LHS)
+trial1 = copy(mcs.rvdict[:name1].dist.values)
+
+generate_trials!(mcs, N, sampling=LHS)
 trial2 = copy(mcs.rvdict[:name1].dist.values)
 
 @test length(trial1) == length(trial2)

--- a/test/mcs/test_empirical.jl
+++ b/test/mcs/test_empirical.jl
@@ -76,9 +76,9 @@ set_dimension!(m, :time, 2000:2001)
 add_comp!(m, test)
 set_model!(mcs_test, m)
 
-generate_trials!(mcs_test, num_trials; filename = "$output_dir/trials.csv", sampling = RANDOM)
+generate_trials!(mcs_test, num_trials; sampling = RANDOM)
 
-run_mcs(mcs_test, num_trials; 
+run_mcs(mcs_test, num_trials;
     output_dir = output_dir,
     scenario_args = scenario_args,
     scenario_func = scenario_func, 
@@ -95,4 +95,16 @@ end
 
 rm(output_dir, recursive = true)
 
-# TODO: Also should test in the case of sampling = LHS, which would currently error
+# Test in the case of sampling = LHS
+
+generate_trials!(mcs_test, num_trials; sampling = LHS)
+trial1 = copy(collect(values(mcs_test.rvdict))[1].dist.values)
+
+for rv in values(mcs_test.rvdict)
+    @test rv.dist isa Mimi.SampleStore
+end
+
+generate_trials!(mcs_test, num_trials; sampling = LHS)
+trial2 = copy(collect(values(mcs_test.rvdict))[1].dist.values)
+
+@test trial1!=trial2


### PR DESCRIPTION
Some of these changes reflect my understanding of what the `dist_rvs` and the `rvdict` fields of a MonteCarloSimulation object are meant to represent.

from conversation on PR #315 : 

Is it that dist_rvs should be considered immutable, preserving the original distributional definitions, whereas rvdict is the one that gets updated to SampleStores and is used for getting trials? @rjplevin is this how we should be thinking of these two fields?