### PR TITLE
WIP component run periods

### DIFF
--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -36,7 +36,7 @@ function _vars_type(md::ModelDef, comp_def::ComponentDef)
     var_defs = variables(comp_def)    
     vnames = Tuple([name(vdef) for vdef in var_defs])
     
-    first = first_period(comp_def, md)
+    first = first_period(md, comp_def)
     vtypes = Tuple{[_instance_datatype(md, vdef, first) for vdef in var_defs]...}
 
     return ComponentInstanceVariables{vnames, vtypes}
@@ -72,7 +72,7 @@ Return the resulting ComponentInstance.
 """
 function _instantiate_component_vars(md::ModelDef, comp_def::ComponentDef)
     comp_name = name(comp_def)
-    first = first_period(comp_def, md)
+    first = first_period(md, comp_def)
     vtype = _vars_type(md, comp_def)
     
     vals = [_instantiate_datum(md, def, first) for def in variables(comp_def)]
@@ -161,8 +161,8 @@ function build(md::ModelDef)
         ptypes = Tuple{map(typeof, pvals)...}
         pars = ComponentInstanceParameters{pnames, ptypes}(pvals)
 
-        first = first_period(comp_def, md)
-        last = last_period(comp_def, md)
+        first = first_period(md, comp_def)
+        last = last_period(md, comp_def)
 
         ci = ComponentInstance{typeof(vars), typeof(pars)}(comp_def, vars, pars, first, last, comp_name)
         add_comp!(mi, ci)

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -36,7 +36,7 @@ function _vars_type(md::ModelDef, comp_def::ComponentDef)
     var_defs = variables(comp_def)    
     vnames = Tuple([name(vdef) for vdef in var_defs])
     
-    first = comp_def.first
+    first = first_period(comp_def, md)
     vtypes = Tuple{[_instance_datatype(md, vdef, first) for vdef in var_defs]...}
 
     return ComponentInstanceVariables{vnames, vtypes}
@@ -72,7 +72,7 @@ Return the resulting ComponentInstance.
 """
 function _instantiate_component_vars(md::ModelDef, comp_def::ComponentDef)
     comp_name = name(comp_def)
-    first = comp_def.first
+    first = first_period(comp_def, md)
     vtype = _vars_type(md, comp_def)
     
     vals = [_instantiate_datum(md, def, first) for def in variables(comp_def)]
@@ -161,7 +161,10 @@ function build(md::ModelDef)
         ptypes = Tuple{map(typeof, pvals)...}
         pars = ComponentInstanceParameters{pnames, ptypes}(pvals)
 
-        ci = ComponentInstance{typeof(vars), typeof(pars)}(comp_def, vars, pars, comp_name)
+        first = first_period(comp_def, md)
+        last = last_period(comp_def, md)
+
+        ci = ComponentInstance{typeof(vars), typeof(pars)}(comp_def, vars, pars, first, last, comp_name)
         add_comp!(mi, ci)
     end
 

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -123,7 +123,7 @@ function connect_param!(md::ModelDef,
         dst_dims  = dimensions(dst_param)
 
         backup = convert(Array{number_type(md)}, backup) # converts number type and, if it's a NamedArray, it's converted to Array
-        first = first_period(dst_comp_def, md)
+        first = first_period(md, dst_comp_def)
         T = eltype(backup)        
         
         dim_count = length(dst_dims)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -46,8 +46,8 @@ function _check_labels(md::ModelDef, comp_def::ComponentDef, param_name::Symbol,
             param_length = size(ext_param.values)[i]
             if dim == :time 
                 t = dimensions(md)[:time]
-                first = first_period(comp_def, md)
-                last = last_period(comp_def, md)
+                first = first_period(md, comp_def)
+                last = last_period(md, comp_def)
                 comp_length = t[last] - t[first] + 1
             else
                 comp_length = dim_count(md, dim)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -46,7 +46,9 @@ function _check_labels(md::ModelDef, comp_def::ComponentDef, param_name::Symbol,
             param_length = size(ext_param.values)[i]
             if dim == :time 
                 t = dimensions(md)[:time]
-                comp_length = t[last_period(comp_def)] - t[first_period(comp_def)] + 1
+                first = first_period(comp_def, md)
+                last = last_period(comp_def, md)
+                comp_length = t[last] - t[first] + 1
             else
                 comp_length = dim_count(md, dim)
             end
@@ -121,7 +123,7 @@ function connect_param!(md::ModelDef,
         dst_dims  = dimensions(dst_param)
 
         backup = convert(Array{number_type(md)}, backup) # converts number type and, if it's a NamedArray, it's converted to Array
-        first = first_period(dst_comp_def)
+        first = first_period(dst_comp_def, md)
         T = eltype(backup)        
         
         dim_count = length(dst_dims)

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -36,10 +36,10 @@ function reset_compdefs(reload_builtins=true)
 end
 
 first_period(comp_def::ComponentDef) = comp_def.first
-first_period(md::ModelDef, comp_def::ComponentDef) = first_period(comp_def) == 0 ? time_labels(md)[1] : first_period(comp_def)
+first_period(md::ModelDef, comp_def::ComponentDef) = first_period(comp_def) == nothing ? time_labels(md)[1] : first_period(comp_def)
 
 last_period(comp_def::ComponentDef) = comp_def.last
-last_period(md::ModelDef, comp_def::ComponentDef) = last_period(comp_def) == 0 ? time_labels(md)[end] : last_period(comp_def)
+last_period(md::ModelDef, comp_def::ComponentDef) = last_period(comp_def) == nothing ? time_labels(md)[end] : last_period(comp_def)
 
 # Return the module object for the component was defined in
 compmodule(comp_id::ComponentId) = comp_id.module_name
@@ -196,13 +196,13 @@ isuniform(md::ModelDef) = md.is_uniform
 function reset_run_periods!(md, first, last)
     for comp_def in compdefs(md)
         change = false
-        if first_period(comp_def) != 0 && first_period(comp_def) < first 
+        if first_period(comp_def) != nothing && first_period(comp_def) < first 
             warn("Resetting $(comp_def.name) component's first timestep to $first")
             change = true
         else
             first = first_period(comp_def)
         end 
-        if last_period(comp_def) != 0 && last_period(comp_def) > last 
+        if last_period(comp_def) != nothing && last_period(comp_def) > last 
             warn("Resetting $(comp_def.name) component's last timestep to $last")
             change = true
         else 
@@ -485,15 +485,11 @@ function add_comp!(md::ModelDef, comp_def::ComponentDef, comp_name::Symbol;
     # check that first and last are within the model's time index range
     time_index = dim_keys(md, :time)
 
-    if first == nothing
-        first = 0
-    elseif first != 0 && first < time_index[1]
+    if first != nothing && first < time_index[1]
         error("Cannot add component $name with first time before first of model's time index range.")
     end
 
-    if last == nothing
-        last = 0
-    elseif last != 0 && last > time_index[end]
+    if last != nothing && last > time_index[end]
         error("Cannot add component $name with last time after end of model's time index range.")
     end
 

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -36,10 +36,10 @@ function reset_compdefs(reload_builtins=true)
 end
 
 first_period(comp_def::ComponentDef) = comp_def.first
-first_period(comp_def::ComponentDef, md::ModelDef) = first_period(comp_def) != 0 ? first_period(comp_def) : time_labels(md)[1]
+first_period(md::ModelDef, comp_def::ComponentDef) = first_period(comp_def) == 0 ? time_labels(md)[1] : first_period(comp_def)
 
 last_period(comp_def::ComponentDef) = comp_def.last
-last_period(comp_def::ComponentDef, md::ModelDef) = last_period(comp_def) != 0 ? last_period(comp_def) : time_labels(md)[end]
+last_period(md::ModelDef, comp_def::ComponentDef) = last_period(comp_def) == 0 ? time_labels(md)[end] : last_period(comp_def)
 
 # Return the module object for the component was defined in
 compmodule(comp_id::ComponentId) = comp_id.module_name
@@ -362,7 +362,7 @@ function set_param!(md::ModelDef, comp_name::Symbol, param_name::Symbol, value, 
                 values = value
             else
                 # Want to use the first from the comp_def if it has it, if not use ModelDef
-                first = first_period(comp_def, md)
+                first = first_period(md, comp_def)
 
                 if isuniform(md)
                     _, stepsize = first_and_step(md)
@@ -446,8 +446,8 @@ end
 # Return the number of timesteps a given component in a model will run for.
 function getspan(md::ModelDef, comp_name::Symbol)
     comp_def = compdef(md, comp_name)
-    first = first_period(comp_def, md)
-    last  = last_period(comp_def, md)
+    first = first_period(md, comp_def)
+    last  = last_period(md, comp_def)
     times = time_labels(md)
     first_index = findfirst(times, first)
     last_index = findfirst(times, last)

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -318,7 +318,8 @@ mutable struct ComponentInstance{TV <: ComponentInstanceVariables, TP <: Compone
     run_timestep::Union{Void, Function}
     
     function ComponentInstance{TV, TP}(comp_def::ComponentDef, 
-                               vars::TV, pars::TP, 
+                               vars::TV, pars::TP,
+                               first::Int, last::Int, 
                                name::Symbol=name(comp_def)) where {TV <: ComponentInstanceVariables, 
                                                                    TP <: ComponentInstanceParameters}
         self = new{TV, TP}()
@@ -327,8 +328,8 @@ mutable struct ComponentInstance{TV <: ComponentInstanceVariables, TP <: Compone
         self.dim_dict = Dict{Symbol, Vector{Int}}()     # set in "build" stage
         self.variables = vars
         self.parameters = pars
-        self.first = comp_def.first
-        self.last = comp_def.last        
+        self.first = first
+        self.last = last        
 
         comp_module = eval(Main, comp_id.module_name)
 

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -203,8 +203,8 @@ mutable struct ComponentDef  <: NamedDef
     variables::OrderedDict{Symbol, DatumDef}
     parameters::OrderedDict{Symbol, DatumDef}
     dimensions::OrderedDict{Symbol, DimensionDef}
-    first::Int
-    last::Int
+    first::Union{Void, Int}
+    last::Union{Void, Int}
 
     # ComponentDefs are created "empty"; elements are subsequently added 
     # to them via addvariable, add_dimension!, etc.
@@ -215,7 +215,7 @@ mutable struct ComponentDef  <: NamedDef
         self.variables  = OrderedDict{Symbol, DatumDef}()
         self.parameters = OrderedDict{Symbol, DatumDef}() 
         self.dimensions = OrderedDict{Symbol, DimensionDef}()
-        self.first = self.last = 0
+        self.first = self.last = nothing
         return self
     end
 end

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -134,8 +134,7 @@ cd = m.md.comp_defs[:C]     # Get the component definition in the model
 @test cd.first == nothing   # First and last values should still be nothing
 @test cd.last == nothing
 
-# update_param!(m, :par1, zeros(16); update_timesteps=true)
-set_param!(m, :C, :par1, zeros(16))
+update_param!(m, :par1, zeros(16); update_timesteps=true)
 Mimi.build(m)               # Build the model
 ci = m.mi.components[:C]    # Get the component instance
 @test ci.first == 2005      # The component instance's first and last values should match the model's index

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -75,10 +75,6 @@ comps = compdefs(my_model)
 @test [compkeys(my_model.md)...] == [:testcomp1, :testcomp2, :testcomp3]
 @test hascomp(my_model.md, :testcomp1) == true && hascomp(my_model.md, :testcomp4) == false
 
-def = compdef(:testcomp3)
-@test first_period(def) == 2015
-@test last_period(def) == 2110
-
 @test compmodule(testcomp3) == :TestComponents
 @test compname(testcomp3) == :testcomp3
 
@@ -87,6 +83,7 @@ add_comp!(my_model, testcomp3, :testcomp3_v2)
 @test numcomponents(my_model) == 4
 
 #Test some component dimensions fcns, other dimensions testing in test_dimensions
+def = compdef(:testcomp3)
 def_dims = dimensions(def)
 @test eltype(def_dims) == Mimi.DimensionDef && length(def_dims) == 1
 @test [def_dims...][1].name == :time
@@ -103,6 +100,15 @@ reset_compdefs(false)
 #------------------------------------------------------------------------------
 #   Tests for component run periods when resetting the model's time dimension
 #------------------------------------------------------------------------------
+
+@defcomp testcomp1 begin
+    var1 = Variable(index=[time])
+    par1 = Parameter(index=[time])
+    
+    function run_timestep(p, v, d, t)
+        v.var1[t] = p.par1[t]
+    end
+end
 
 # 1. Test resetting the time dimension without explicit first/last values 
 
@@ -128,7 +134,8 @@ cd = m.md.comp_defs[:C]     # Get the component definition in the model
 @test cd.first == 0         # First and last values should still be zero
 @test cd.last == 0
 
-update_param!(m, :par1, zeros(16); update_timesteps=true)
+# update_param!(m, :par1, zeros(16); update_timesteps=true)
+set_param!(m, :C, :par1, zeros(16))
 Mimi.build(m)               # Build the model
 ci = m.mi.components[:C]    # Get the component instance
 @test ci.first == 2005      # The component instance's first and last values should match the model's index

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -113,15 +113,15 @@ end
 # 1. Test resetting the time dimension without explicit first/last values 
 
 cd = compdef(testcomp1)    
-@test cd.first == 0         # original component definition's first and last values are unset
-@test cd.last == 0
+@test cd.first == nothing   # original component definition's first and last values are unset
+@test cd.last == nothing
 
 m = Model()
 set_dimension!(m, :time, 2001:2005)
 add_comp!(m, testcomp1, :C) # Don't set the first and last values here
 cd = m.md.comp_defs[:C]     # Get the component definition in the model
-@test cd.first == 0         # First and last values should still be zero because they were not explicitly set
-@test cd.last == 0
+@test cd.first == nothing   # First and last values should still be nothing because they were not explicitly set
+@test cd.last == nothing
 
 set_param!(m, :C, :par1, zeros(5))
 Mimi.build(m)               # Build the model
@@ -131,8 +131,8 @@ ci = m.mi.components[:C]    # Get the component instance
 
 set_dimension!(m, :time, 2005:2020) # Reset the time dimension
 cd = m.md.comp_defs[:C]     # Get the component definition in the model
-@test cd.first == 0         # First and last values should still be zero
-@test cd.last == 0
+@test cd.first == nothing   # First and last values should still be nothing
+@test cd.last == nothing
 
 # update_param!(m, :par1, zeros(16); update_timesteps=true)
 set_param!(m, :C, :par1, zeros(16))

--- a/test/test_metainfo.jl
+++ b/test/test_metainfo.jl
@@ -53,7 +53,7 @@ vars = Mimi.variable_names(c2)
 pars = Mimi.parameter_names(c2)
 @test length(pars) == 6
 
-@test first_period(c1, test_model.md) == 2010
-@test last_period(c1, test_model.md) == 2100
+@test first_period(test_model.md, c1) == 2010
+@test last_period(test_model.md, c1) == 2100
 
 end # module

--- a/test/test_metainfo.jl
+++ b/test/test_metainfo.jl
@@ -53,7 +53,7 @@ vars = Mimi.variable_names(c2)
 pars = Mimi.parameter_names(c2)
 @test length(pars) == 6
 
-@test first_period(c1) == 2010
-@test last_period(c1) == 2100
+@test first_period(c1, test_model.md) == 2010
+@test last_period(c1, test_model.md) == 2100
 
 end # module

--- a/test/test_metainfo_variabletimestep.jl
+++ b/test/test_metainfo_variabletimestep.jl
@@ -53,7 +53,7 @@ vars = Mimi.variable_names(c2)
 pars = Mimi.parameter_names(c2)
 @test length(pars) == 6
 
-@test first_period(c1, test_model.md) == 2010
-@test last_period(c1, test_model.md) == 2200
+@test first_period(test_model.md, c1) == 2010
+@test last_period(test_model.md, c1) == 2200
 
 end # module

--- a/test/test_metainfo_variabletimestep.jl
+++ b/test/test_metainfo_variabletimestep.jl
@@ -53,7 +53,7 @@ vars = Mimi.variable_names(c2)
 pars = Mimi.parameter_names(c2)
 @test length(pars) == 6
 
-@test first_period(c1) == 2010
-@test last_period(c1) == 2200
+@test first_period(c1, test_model.md) == 2010
+@test last_period(c1, test_model.md) == 2200
 
 end # module

--- a/test/test_model_structure.jl
+++ b/test/test_model_structure.jl
@@ -163,7 +163,7 @@ set_param!(m, :E, :parE2, 10)
 run(m)
 @test m[:E, :varE] == 10
 
-set_dimension!(m, :time, 2015) #run for just one timestep, so init sets the value here
+set_dimension!(m, :time, [2015]) #run for just one timestep, so init sets the value here
 run(m)
 @test m[:E, :varE] == 1
 


### PR DESCRIPTION
issue #306 

Changes:
- Component definitions have their first and last values set to `nothing`, unless calls to `add_comp!` explicitly give values
- Component instances get their first and last values set to the first and last values from the component definitions if they are not `nothing`, or from the model's time index at that point
- This involved modifying the ComponentInstance constructor to explicitly take first and last values
- additional internal helper functions were added:
```
first_period(md::ModelDef, comp_def::ComponentDef) = first_period(comp_def) == nothing ? time_labels(md)[1] : first_period(comp_def)
last_period(md::ModelDef, comp_def::ComponentDef) = last_period(comp_def) == nothing ? time_labels(md)[end] : last_period(comp_def)
```
- most internal uses of the functions `first_period(comp_def)` and `last_period(comp_def)` are now replaced with `first_period(comp_def, md)` and `last_period(comp_def, md)` (i.e. in `set_param!` and `_check_labels`)
- new explicit testing of this functionality is found in "test/test_components.jl", but testing in a few other test files also had to be modified


Questions:

- I didn't use the constant `VoidInt` type in the CompDef struct definition because it's defined in a file that's loaded after types.jl get's loaded, and I felt like it was fine to just use the explicit `Union{Void, Int}` here, but let me know if I should move the constant definition into the types.jl file so that it gets used here
