### PR TITLE
WIP Datum Storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi 
   - $TESTCMD --check-bounds=yes -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("Mimi"); Pkg.test("Mimi"; coverage=true)'
-  - julia --check-bounds=yes -e 'include("test/test_dependencies.jl"); run_dependency_tests()'
+#  - julia --check-bounds=yes -e 'include("test/test_dependencies.jl"); run_dependency_tests()'
 after_success:
   - julia -e 'using Pkg; cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'using Pkg; cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,7 +1,9 @@
 using BenchmarkTools
 
 include("RegionTutorialBenchmarks.jl")
+include("getindex.jl")
 
 const SUITE = BenchmarkGroup()
 SUITE["one_region"] = @benchmarkable run_oneregion() 
 SUITE["two_regions"] = @benchmarkable run_tworegion()
+SUITE["getindex"] = @benchmarkable run_getindex()

--- a/benchmark/getindex.jl
+++ b/benchmark/getindex.jl
@@ -1,0 +1,55 @@
+using Mimi
+
+_default_years = 2000:2100
+_default_regions = [:A, :B]
+
+function run_getindex(; years = collect(_default_years), regions = _default_regions)
+    # Test with one scalar parameter, one 1-D timestep array, and one 2-D timestep array
+    types = [Mimi.ScalarModelParameter{Float64}, _get_timesteparray_type(years, 1), _get_timesteparray_type(years, 2)]
+
+    names = [:d1, :d2, :d3]
+    values = [
+        types[1](4.),
+        types[2](Array{Union{Missing, Float64}, 1}(rand(length(years)))), 
+        types[3](Array{Union{Missing, Float64}, 2}(rand(length(years), length(regions))))
+        ]
+
+    datum = NamedTuple{(names...,), Tuple{types...,}}(values)
+    
+    clock = _get_clock(years)
+
+    while ! Mimi.finished(clock)
+        ts = Mimi.timestep(clock)
+        _run_timestep(datum, ts)
+        Mimi.advance(clock)
+    end 
+end 
+
+function _run_timestep(datum::NamedTuple, ts)
+    datum.d1
+    datum.d2[ts]
+    datum.d3[ts, :]
+    nothing
+end 
+
+function _get_timesteparray_type(years, num_dims, dtype=Float64)
+    if Mimi.isuniform(years)
+        first, stepsize = Mimi.first_and_step(years)
+        T = Mimi.TimestepArray{Mimi.FixedTimestep{first, stepsize}, Union{dtype, Missing}, num_dims}
+    else
+        T = Mimi.TimestepArray{Mimi.VariableTimestep{(years...,)}, Union{dtype, Missing}, num_dims}
+    end
+    return T
+end 
+
+function _get_clock(years)
+    if Mimi.isuniform(years)
+        last = years[end]
+        first, stepsize = Mimi.first_and_step(years)
+        return Mimi.Clock{Mimi.FixedTimestep}(first, stepsize, last)
+    else
+        last_index = findfirst(isequal(last), years)
+        times = (years[1:last_index]...,)
+        return Mimi.Clock{Mimi.VariableTimestep}(times)
+    end
+end

--- a/src/components/connector.jl
+++ b/src/components/connector.jl
@@ -6,12 +6,14 @@ using Mimi
     output =  Variable(index = [time])
 
     function run_timestep(p, v, d, ts)
-        if !ismissing(p.input1[ts])
+        try 
             v.output[ts] = p.input1[ts]
-        elseif !ismissing(p.input2[ts])
-            v.output[ts] = p.input2[ts]
-        else
-            error("Neither of the inputs to ConnectorCompVector have data for the current timestep: $(gettime(ts)).")
+        catch 
+            try 
+                v.output[ts] = p.input2[ts]
+            catch 
+                error("Neither of the inputs to ConnectorCompVector have data for the current timestep: $(gettime(ts)).")
+            end
         end
     end
 end
@@ -25,12 +27,14 @@ end
 
     function run_timestep(p, v, d, ts)
         for r in d.regions
-            if !ismissing(p.input1[ts, r])
+            try 
                 v.output[ts, r] = p.input1[ts, r]
-            elseif !ismissing(p.input2[ts, r])
-                v.output[ts, r] = p.input2[ts, r]
-            else
-                error("Neither of the inputs to ConnectorCompMatrix have data for the current timestep: $(gettime(ts)).")
+            catch 
+                try 
+                    v.output[ts, r] = p.input2[ts, r]
+                catch 
+                    error("Neither of the inputs to ConnectorCompMatrix have data for the current timestep: $(gettime(ts)).")
+                end
             end
         end
     end

--- a/src/components/connector.jl
+++ b/src/components/connector.jl
@@ -6,9 +6,9 @@ using Mimi
     output =  Variable(index = [time])
 
     function run_timestep(p, v, d, ts)
-        if hasvalue(p.input1, ts)
+        if !ismissing(p.input1[ts])
             v.output[ts] = p.input1[ts]
-        elseif hasvalue(p.input2, ts)
+        elseif !ismissing(p.input2[ts])
             v.output[ts] = p.input2[ts]
         else
             error("Neither of the inputs to ConnectorCompVector have data for the current timestep: $(gettime(ts)).")
@@ -25,9 +25,9 @@ end
 
     function run_timestep(p, v, d, ts)
         for r in d.regions
-            if hasvalue(p.input1, ts, r)
+            if !ismissing(p.input1[ts, r])
                 v.output[ts, r] = p.input1[ts, r]
-            elseif hasvalue(p.input2, ts, r)
+            elseif !ismissing(p.input2[ts, r])
                 v.output[ts, r] = p.input2[ts, r]
             else
                 error("Neither of the inputs to ConnectorCompMatrix have data for the current timestep: $(gettime(ts)).")

--- a/src/components/connector.jl
+++ b/src/components/connector.jl
@@ -5,16 +5,15 @@ using Mimi
     input2 = Parameter(index = [time])
     output =  Variable(index = [time])
 
+    first = Parameter() # first year to use the shorter data
+    last = Parameter()  # last year to use the shorter data
+
     function run_timestep(p, v, d, ts)
-        try 
+        if gettime(ts) >= p.first && gettime(ts) <= p.last
             v.output[ts] = p.input1[ts]
-        catch 
-            try 
-                v.output[ts] = p.input2[ts]
-            catch 
-                error("Neither of the inputs to ConnectorCompVector have data for the current timestep: $(gettime(ts)).")
-            end
-        end
+        else
+            v.output[ts] = p.input2[ts]
+        end 
     end
 end
 
@@ -25,17 +24,14 @@ end
     input2 = Parameter(index = [time, regions])
     output =  Variable(index = [time, regions])
 
+    first = Parameter() # first year to use the shorter data
+    last = Parameter()  # last year to use the shorter data
+
     function run_timestep(p, v, d, ts)
-        for r in d.regions
-            try 
-                v.output[ts, r] = p.input1[ts, r]
-            catch 
-                try 
-                    v.output[ts, r] = p.input2[ts, r]
-                catch 
-                    error("Neither of the inputs to ConnectorCompMatrix have data for the current timestep: $(gettime(ts)).")
-                end
-            end
+        if gettime(ts) >= p.first && gettime(ts) <= p.last 
+            v.output[ts, :] = p.input1[ts, :]
+        else
+            v.output[ts, :] = p.input2[ts, :]
         end
     end
 end

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -38,7 +38,6 @@ function _instantiate_datum(md::ModelDef, def::DatumDef)
       
     # Array datum, with :time dimension
     elseif dims[1] == :time 
-        times = time_labels(md)
 
         if num_dims == 1
             value = dtype(dim_count(md, :time))
@@ -49,7 +48,6 @@ function _instantiate_datum(md::ModelDef, def::DatumDef)
 
     # Array datum, without :time dimension
     else 
-        # if dims[1] != :time
         # TBD: Handle unnamed indices properly
         counts = dim_counts(md, Vector{Symbol}(dims))
         value = dtype <: AbstractArray ? dtype(undef, counts...) : dtype(counts...)

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -27,7 +27,6 @@ function _instance_datatype(md::ModelDef, def::DatumDef)
 end
 
 # Create the Ref or Array that will hold the value(s) for a Parameter or Variable
-# function _instantiate_datum(md::ModelDef, def::DatumDef, first::Int, last::Int) # only need the component first and last if we manually need to set NaN values; if we use 'missing' values they get set automatically
 function _instantiate_datum(md::ModelDef, def::DatumDef)
     dtype = _instance_datatype(md, def)
     dims = dimensions(def)
@@ -43,19 +42,10 @@ function _instantiate_datum(md::ModelDef, def::DatumDef)
 
         if num_dims == 1
             value = dtype(dim_count(md, :time))
-            # indices = 1:length(times)
         else 
             counts = dim_counts(md, Vector{Symbol}(dims))
             value = dtype <: AbstractArray ? dtype(undef, counts...) : dtype(counts...)
-            # indices = [(i, (1:c for c in counts[2:end])...) for i in 1:length(times)]
         end
-
-        # Fill in missing values before and after first and last times (don't need to do this for missing, only if we use NaNs)
-        # for (i, t) in enumerate(times)
-        #     if t < first || t > last
-        #         value[indices[i]...] = NaN
-        #     end
-        # end
 
     # Array datum, without :time dimension
     else 
@@ -88,12 +78,10 @@ Return the resulting ComponentInstance.
 """
 function _instantiate_component_vars(md::ModelDef, comp_def::ComponentDef)
     comp_name = name(comp_def)
-    # first, last = first_period(md, comp_def), last_period(md, comp_def)
     var_defs = variables(comp_def)    
 
     names  = ([name(vdef) for vdef in var_defs]...,)
     types  = Tuple{[_instance_datatype(md, vdef) for vdef in var_defs]...}
-    # values = [_instantiate_datum(md, def, first, last) for def in var_defs]
     values = [_instantiate_datum(md, def) for def in var_defs]
 
     return ComponentInstanceVariables(names, types, values)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -114,8 +114,8 @@ function connect_param!(md::ModelDef,
         end
 
         # Check that the backup value is the right size
-        if size(backup)[1] != length(time_labels(md))  # TODO: should it be the length of the whole model or the lenght of the component? for now, lenght of the model
-            error("Can't connect parameter: backup data size $(size(backup)) differs from model's time span $(length(time_labels(md))).")
+        if size(backup)[1] != getspan(md, dst_comp_name)[1]
+            error("Cannot connect parameter, backup data's length differs from component's time span. Expected length $(getspan(md, dst_comp_name)[1]) but got length $(size(backup)[1]).")
         end
 
         dst_comp_def = compdef(md, dst_comp_name)

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -116,9 +116,9 @@ function connect_param!(md::ModelDef,
             dims = nothing
         end
 
-        # Check that the backup value is the right size
-        if size(backup)[1] != getspan(md, dst_comp_name)[1]
-            error("Cannot connect parameter, backup data's length differs from component's time span. Expected length $(getspan(md, dst_comp_name)[1]) but got length $(size(backup)[1]).")
+        # Check that the backup data is the right size
+        if size(backup) != datum_size(md, dst_comp_def, dst_par_name)
+            error("Cannot connect parameter; the provided backup data is the wrong size. Expected size $(datum_size(md, dst_comp_def, dst_par_name)) but got $(size(backup)).")
         end
 
         # some other check for second dimension??

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -504,6 +504,10 @@ function add_connector_comps(md::ModelDef)
             # add a connection between ConnectorComp and the external backup data
             push!(md.external_param_conns, ExternalParameterConnection(conn_comp_name, :input2, conn.backup))
 
+            src_comp_def = compdef(md, conn.src_comp_name)
+            set_param!(md, conn_comp_name, :first, first_period(md, src_comp_def))
+            set_param!(md, conn_comp_name, :last, last_period(md, src_comp_def))
+
         end
     end
 

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -171,6 +171,19 @@ function check_parameter_dimensions(md::ModelDef, value::AbstractArray, dims::Ve
     end
 end
 
+function datum_size(md::ModelDef, comp_def::ComponentDef, datum_name::Symbol)
+    dims = dimensions(comp_def, datum_name)
+    if dims[1] == :time
+        time_length = getspan(md, comp_def)[1]
+        rest_dims = filter(x->x!=:time, dims)
+        datum_size = (time_length, dim_counts(md, rest_dims)...,)
+    else
+        datum_size = (dim_counts(md, dims)...,)
+    end
+    return datum_size
+end
+
+
 dimensions(md::ModelDef) = md.dimensions
 dimensions(md::ModelDef, dims::Vector{Symbol}) = [dimension(md, dim) for dim in dims]
 dimension(md::ModelDef, name::Symbol) = md.dimensions[name]
@@ -451,6 +464,10 @@ end
 # Return the number of timesteps a given component in a model will run for.
 function getspan(md::ModelDef, comp_name::Symbol)
     comp_def = compdef(md, comp_name)
+    return getspan(md, comp_def)
+end
+
+function getspan(md::ModelDef, comp_def::ComponentDef)
     first = first_period(md, comp_def)
     last  = last_period(md, comp_def)
     times = time_labels(md)

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -74,7 +74,7 @@ function Base.:-(ts::FixedTimestep{FIRST, STEP, LAST}, val::Int) where {FIRST, S
 	if is_first(ts)
 		error("Cannot get previous timestep, this is first timestep.")
 	elseif ts.t - val <= 0
-		error("Cannot get requested timestep, preceeds first timestep.")		
+		error("Cannot get requested timestep, precedes first timestep.")		
 	end
 	return FixedTimestep{FIRST, STEP, LAST}(ts.t - val)
 end
@@ -83,7 +83,7 @@ function Base.:-(ts::VariableTimestep{TIMES}, val::Int) where {TIMES}
 	if is_first(ts)
 		error("Cannot get previous timestep, this is first timestep.")
 	elseif ts.t - val <= 0
-		error("Cannot get requested timestep, preceeds first timestep.")		
+		error("Cannot get requested timestep, precedes first timestep.")		
 	end
 	return VariableTimestep{TIMES}(ts.t - val)
 end

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -186,36 +186,40 @@ const AnyIndex = Union{Int, Vector{Int}, Tuple, Colon, OrdinalRange}
 
 function Base.getindex(v::TimestepVector{FixedTimestep{FIRST, STEP}, T}, ts::FixedTimestep{FIRST, STEP, LAST}) where {T, FIRST, STEP, LAST} 
 	data = v.data[ts.t]
-	if ismissing(data)
+	if data === missing
 		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	else
+		return data
 	end
-	return data
 end
 
 function Base.getindex(v::TimestepVector{VariableTimestep{TIMES}, T}, ts::VariableTimestep{TIMES}) where {T, TIMES}
 	data = v.data[ts.t]
-	if ismissing(data)
+	if data === missing
 		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	else
+		return data
 	end
-	return data
 end
 
 function Base.getindex(v::TimestepVector{FixedTimestep{D_FIRST, STEP}, T}, ts::FixedTimestep{T_FIRST, STEP, LAST}) where {T, D_FIRST, T_FIRST, STEP, LAST} 
 	t = Int(ts.t + (T_FIRST - D_FIRST) / STEP)
 	data = v.data[t]
-	if ismissing(data)
+	if data === missing
 		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	else
+		return data
 	end
-	return data
 end
 
 function Base.getindex(v::TimestepVector{VariableTimestep{D_FIRST}, T}, ts::VariableTimestep{T_FIRST}) where {T, D_FIRST, T_FIRST}
 	t = ts.t + findfirst(isequal(T_FIRST[1]), D_FIRST) - 1
 	data = v.data[t]
-	if ismissing(data)
+	if data === missing
 		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	else
+		return data
 	end
-	return data
 end
 
 # int indexing version supports old-style components and internal functions, not
@@ -270,36 +274,40 @@ Base.lastindex(v::TimestepVector) = length(v)
 
 function Base.getindex(mat::TimestepMatrix{FixedTimestep{FIRST, STEP}, T}, ts::FixedTimestep{FIRST, STEP, LAST}, i::AnyIndex) where {T, FIRST, STEP, LAST} 
 	data = mat.data[ts.t, i]
-	if ismissing(data)
+	if data === missing
 		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	else
+		return data
 	end
-	return data
 end
 
 function Base.getindex(mat::TimestepMatrix{VariableTimestep{TIMES}, T}, ts::VariableTimestep{TIMES}, i::AnyIndex) where {T, TIMES}
 	data = mat.data[ts.t, i]
-	if ismissing(data)
+	if data === missing
 		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	else
+		return data
 	end
-	return data
 end
 
 function Base.getindex(mat::TimestepMatrix{FixedTimestep{D_FIRST, STEP}, T}, ts::FixedTimestep{T_FIRST, STEP, LAST}, i::AnyIndex) where {T, D_FIRST, T_FIRST, STEP, LAST} 
 	t = Int(ts.t + (T_FIRST - D_FIRST) / STEP)
 	data = mat.data[t, i]
-	if ismissing(data)
+	if data === missing
 		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	else
+		return data
 	end
-	return data
 end
 
 function Base.getindex(mat::TimestepMatrix{VariableTimestep{D_FIRST}, T}, ts::VariableTimestep{T_FIRST}, i::AnyIndex) where {T, D_FIRST, T_FIRST}
 	t = ts.t + findfirst(isequal(T_FIRST[1]), D_FIRST) - 1
 	data = mat.data[t, i]
-	if ismissing(data)
+	if data === missing
 		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	else
+		return data
 	end
-	return data
 end
 
 # int indexing version supports old-style components and internal functions, not

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -167,21 +167,37 @@ const AnyIndex = Union{Int, Vector{Int}, Tuple, Colon, OrdinalRange}
 #
 
 function Base.getindex(v::TimestepVector{FixedTimestep{FIRST, STEP}, T}, ts::FixedTimestep{FIRST, STEP, LAST}) where {T, FIRST, STEP, LAST} 
-	return v.data[ts.t]
+	data = v.data[ts.t]
+	if ismissing(data)
+		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	end
+	return data
 end
 
 function Base.getindex(v::TimestepVector{VariableTimestep{TIMES}, T}, ts::VariableTimestep{TIMES}) where {T, TIMES}
-	return v.data[ts.t]
+	data = v.data[ts.t]
+	if ismissing(data)
+		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	end
+	return data
 end
 
 function Base.getindex(v::TimestepVector{FixedTimestep{D_FIRST, STEP}, T}, ts::FixedTimestep{T_FIRST, STEP, LAST}) where {T, D_FIRST, T_FIRST, STEP, LAST} 
 	t = Int(ts.t + (T_FIRST - D_FIRST) / STEP)
-	return v.data[t]
+	data = v.data[t]
+	if ismissing(data)
+		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	end
+	return data
 end
 
 function Base.getindex(v::TimestepVector{VariableTimestep{D_FIRST}, T}, ts::VariableTimestep{T_FIRST}) where {T, D_FIRST, T_FIRST}
 	t = ts.t + findfirst(isequal(T_FIRST[1]), D_FIRST) - 1
-	return v.data[t]
+	data = v.data[t]
+	if ismissing(data)
+		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	end
+	return data
 end
 
 # int indexing version supports old-style components and internal functions, not
@@ -235,21 +251,37 @@ Base.lastindex(v::TimestepVector) = length(v)
 #
 
 function Base.getindex(mat::TimestepMatrix{FixedTimestep{FIRST, STEP}, T}, ts::FixedTimestep{FIRST, STEP, LAST}, i::AnyIndex) where {T, FIRST, STEP, LAST} 
-	return mat.data[ts.t, i]
+	data = mat.data[ts.t, i]
+	if ismissing(data)
+		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	end
+	return data
 end
 
 function Base.getindex(mat::TimestepMatrix{VariableTimestep{TIMES}, T}, ts::VariableTimestep{TIMES}, i::AnyIndex) where {T, TIMES}
-	return mat.data[ts.t, i]
+	data = mat.data[ts.t, i]
+	if ismissing(data)
+		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	end
+	return data
 end
 
 function Base.getindex(mat::TimestepMatrix{FixedTimestep{D_FIRST, STEP}, T}, ts::FixedTimestep{T_FIRST, STEP, LAST}, i::AnyIndex) where {T, D_FIRST, T_FIRST, STEP, LAST} 
 	t = Int(ts.t + (T_FIRST - D_FIRST) / STEP)
-	return return mat.data[t, i]
+	data = mat.data[t, i]
+	if ismissing(data)
+		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	end
+	return data
 end
 
 function Base.getindex(mat::TimestepMatrix{VariableTimestep{D_FIRST}, T}, ts::VariableTimestep{T_FIRST}, i::AnyIndex) where {T, D_FIRST, T_FIRST}
 	t = ts.t + findfirst(isequal(T_FIRST[1]), D_FIRST) - 1
-	return return mat.data[t, i]
+	data = mat.data[t, i]
+	if ismissing(data)
+		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+	end
+	return data
 end
 
 # int indexing version supports old-style components and internal functions, not

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,11 +77,12 @@ Mimi.set_defcomp_verbosity(false)
 
     @info("test_dimensions")
     include("test_dimensions.jl")
+
+    @info("test_datum_storage.jl")
+    include("test_datum_storage.jl")
     
-    # fails currently
-    # TODO Reenable
-    # @info("test_connectorcomp.jl")
-    # include("test_connectorcomp.jl")
+    @info("test_connectorcomp.jl")
+    include("test_connectorcomp.jl")
 
     @info("test_explorer.jl")
     include("test_explorer.jl")

--- a/test/test_connectorcomp.jl
+++ b/test/test_connectorcomp.jl
@@ -25,80 +25,26 @@ years = 2000:2010
 late_start = 2005
 dim = Mimi.Dimension(years)
 
-#------------------------------------------------------------------------------
-#  1. Manual way of using ConnectorComp
-#       TODO: are we no longer allowing users to add ConnectorComps manually?
-#       Currently deprecated because of checks for full/backup data during
-#       calls to connect_param!
-#------------------------------------------------------------------------------
-
-# m = Model()
-# set_dimension!(m, :time, years)
-
-# add_comp!(m, Short; first=late_start)
-# add_comp!(m, Mimi.ConnectorCompVector, :MyConnector) # Rename component in this model
-# add_comp!(m, Long)
-
-# comp_def = compdef(m, :MyConnector)
-# @test Mimi.compname(comp_def.comp_id) == :ConnectorCompVector
-
-# set_param!(m, :Short, :a, 2.)
-# connect_param!(m, :MyConnector, :input1, :Short, :b)
-
-# set_param!(m, :MyConnector, :input2, zeros(length(years)))
-# connect_param!(m, :Long, :x, :MyConnector, :output)
-
-# run(m)
-
-# b = m[:Short, :b]
-# input1 = m[:MyConnector, :input1]
-# output = m[:MyConnector, :output]
-# x = m[:Long, :x]
-
-# # Test that all allocated datum arrays are the full length of the time dimension
-# @test length(b) == length(years)
-# @test length(input1) == length(years)
-# @test length(output) == length(years)
-# @test length(x) == length(years)
-
-# # Test the values are the right values before the late start
-# @test all(ismissing, b[1:dim[late_start]-1])
-# @test all(ismissing, input1[1:dim[late_start]-1])
-# @test all(iszero, output[1:dim[late_start]-1])
-# @test all(iszero, x[1:dim[late_start]-1])
-
-# # Test the values are right after the late start
-# @test b[dim[late_start]:end] == 
-#     input1[dim[late_start]:end] == 
-#     output[dim[late_start]:end] == 
-#     x[dim[late_start]:end] == 
-#     [2 * i for i in 1:(years[end]-late_start + 1)]
-
-# # Test the dataframe size
-# b = getdataframe(m, :Short, :b)
-# @test size(b) == (length(years), 2)
-
 
 #------------------------------------------------------------------------------
-#  2. Use the connect_param! method with backup data (ConnectorComp gets added 
+#  1. Use the connect_param! method with backup data (ConnectorComp gets added 
 #       under the hood during build)
 #------------------------------------------------------------------------------
 
-model2 = Model()
-set_dimension!(model2, :time, years)
-add_comp!(model2, Short; first=late_start)
-add_comp!(model2, Long)
-set_param!(model2, :Short, :a, 2.)
-connect_param!(model2, :Long, :x, :Short, :b, zeros(length(years)))
+model1 = Model()
+set_dimension!(model1, :time, years)
+add_comp!(model1, Short; first=late_start)
+add_comp!(model1, Long)
+set_param!(model1, :Short, :a, 2.)
+connect_param!(model1, :Long, :x, :Short, :b, zeros(length(years)))
 
-run(model2)
+run(model1)
 
-# @test length(components(model2.mi)) == 2
-@test length(components(model2.mi)) == 3    # is there a way to prevent this? ConnectorComp is added to the list of components in the model isntance
-@test length(model2.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
+@test length(components(model1.mi)) == 3    # ConnectorComp is added to the list of components in the model isntance
+@test length(model1.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b = model2[:Short, :b]
-x = model2[:Long, :x]
+b = model1[:Short, :b]
+x = model1[:Long, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
 @test length(b) == length(years)
@@ -112,10 +58,14 @@ x = model2[:Long, :x]
     x[dim[late_start]:end] == 
     [2 * i for i in 1:(years[end]-late_start + 1)]
 
-@test Mimi.datum_size(model2.md, Mimi.compdef(model2.md, :Long), :x) == (length(years),)
+@test Mimi.datum_size(model1.md, Mimi.compdef(model1.md, :Long), :x) == (length(years),)
+
+# Test the dataframe size
+b = getdataframe(model1, :Short, :b)
+@test size(b) == (length(years), 2)
  
 #------------------------------------------------------------------------------
-#  3. Test with a short component that ends early (and test Variable timesteps)
+#  2. Test with a short component that ends early (and test Variable timesteps)
 #------------------------------------------------------------------------------
 
 years_variable = [2000:2004..., 2005:5:2030...]
@@ -123,20 +73,20 @@ dim_variable = Mimi.Dimension(years_variable)
 
 early_last = 2010
 
-model3 = Model()
-set_dimension!(model3, :time, years_variable)
-add_comp!(model3, Short; last=early_last)
-add_comp!(model3, Long)
-set_param!(model3, :Short, :a, 2.)
-connect_param!(model3, :Long, :x, :Short, :b, zeros(length(years_variable)))
+model2 = Model()
+set_dimension!(model2, :time, years_variable)
+add_comp!(model2, Short; last=early_last)
+add_comp!(model2, Long)
+set_param!(model2, :Short, :a, 2.)
+connect_param!(model2, :Long, :x, :Short, :b, zeros(length(years_variable)))
 
-run(model3)
+run(model2)
 
-@test length(components(model3.mi)) == 3    
-@test length(model3.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
+@test length(components(model2.mi)) == 3    
+@test length(model2.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b = model3[:Short, :b]
-x = model3[:Long, :x]
+b = model2[:Short, :b]
+x = model2[:Long, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
 @test length(b) == length(years_variable)
@@ -152,7 +102,7 @@ x = model3[:Long, :x]
 
 
 #------------------------------------------------------------------------------
-#  4. A model that requires multiregional ConnectorComps
+#  3. A model that requires multiregional ConnectorComps
 #------------------------------------------------------------------------------
 
 @defcomp Long_multi begin
@@ -176,21 +126,21 @@ end
 
 regions = [:A, :B]
 
-model4 = Model()
-set_dimension!(model4, :time, years)
-set_dimension!(model4, :regions, regions)
-add_comp!(model4, Short_multi; first=late_start)
-add_comp!(model4, Long_multi)
-set_param!(model4, :Short_multi, :a, [1,2])
-connect_param!(model4, :Long_multi, :x, :Short_multi, :b, zeros(length(years), length(regions)))
+model3 = Model()
+set_dimension!(model3, :time, years)
+set_dimension!(model3, :regions, regions)
+add_comp!(model3, Short_multi; first=late_start)
+add_comp!(model3, Long_multi)
+set_param!(model3, :Short_multi, :a, [1,2])
+connect_param!(model3, :Long_multi, :x, :Short_multi, :b, zeros(length(years), length(regions)))
 
-run(model4)
+run(model3)
 
-@test length(components(model4.mi)) == 3    
-@test length(model4.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
+@test length(components(model3.mi)) == 3    
+@test length(model3.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b = model4[:Short_multi, :b]
-x = model4[:Long_multi, :x]
+b = model3[:Short_multi, :b]
+x = model3[:Long_multi, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
 @test size(b) == (length(years), length(regions))
@@ -206,27 +156,27 @@ x = model4[:Long_multi, :x]
 
 
 #------------------------------------------------------------------------------
-#  5. Test where the short component starts late and ends early
+#  4. Test where the short component starts late and ends early
 #------------------------------------------------------------------------------
 
 first, last = 2002, 2007
 
-model5 = Model()
-set_dimension!(model5, :time, years)
-set_dimension!(model5, :regions, regions)
-add_comp!(model5, Short_multi; first=first, last=last)
-add_comp!(model5, Long_multi)
+model4 = Model()
+set_dimension!(model4, :time, years)
+set_dimension!(model4, :regions, regions)
+add_comp!(model4, Short_multi; first=first, last=last)
+add_comp!(model4, Long_multi)
 
-set_param!(model5, :Short_multi, :a, [1,2])
-connect_param!(model5, :Long_multi=>:x, :Short_multi=>:b, zeros(length(years), length(regions)))
+set_param!(model4, :Short_multi, :a, [1,2])
+connect_param!(model4, :Long_multi=>:x, :Short_multi=>:b, zeros(length(years), length(regions)))
 
-run(model5)
+run(model4)
 
-@test length(components(model5.mi)) == 3    
-@test length(model5.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
+@test length(components(model4.mi)) == 3    
+@test length(model4.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b = model5[:Short_multi, :b]
-x = model5[:Long_multi, :x]
+b = model4[:Short_multi, :b]
+x = model4[:Long_multi, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
 @test size(b) == (length(years), length(regions))
@@ -244,28 +194,28 @@ x = model5[:Long_multi, :x]
 
 
 #------------------------------------------------------------------------------
-#  6. Test errors with backup data
+#  5. Test errors with backup data
 #------------------------------------------------------------------------------
 
 late_start_long = 2002
 
-model6 = Model()
-set_dimension!(model6, :time, years)
-add_comp!(model6, Short; first = late_start)
-add_comp!(model6, Long; first = late_start_long)    # starts later as well, so backup data needs to match this size
-set_param!(model6, :Short, :a, 2)
+model5 = Model()
+set_dimension!(model5, :time, years)
+add_comp!(model5, Short; first = late_start)
+add_comp!(model5, Long; first = late_start_long)    # starts later as well, so backup data needs to match this size
+set_param!(model5, :Short, :a, 2)
 
 # A. test wrong size (needs to be length of component, not length of model)
-@test_throws ErrorException connect_param!(model6, :Long=>:x, :Short=>:b, zeros(length(years)))
-@test_throws ErrorException connect_param!(model5, :Long_multi=>:x, :Short_multi=>:b, zeros(length(years), length(regions)+1)) # test case with >1 dimension
+@test_throws ErrorException connect_param!(model5, :Long=>:x, :Short=>:b, zeros(length(years)))
+@test_throws ErrorException connect_param!(model4, :Long_multi=>:x, :Short_multi=>:b, zeros(length(years), length(regions)+1)) # test case with >1 dimension
 
 
 # B. test no backup data provided
-@test_throws ErrorException connect_param!(model6, :Long=>:x, :Short=>:b)   # Error because no backup data provided
+@test_throws ErrorException connect_param!(model5, :Long=>:x, :Short=>:b)   # Error because no backup data provided
 
 
 #------------------------------------------------------------------------------
-#  7. Test connecting Short component to Long component (does not add a 
+#  6. Test connecting Short component to Long component (does not add a 
 #       connector component)
 #------------------------------------------------------------------------------
 
@@ -277,19 +227,19 @@ set_param!(model6, :Short, :a, 2)
     end
 end
 
-model7 = Model()
-set_dimension!(model7, :time, years)
-add_comp!(model7, foo, :Long)
-add_comp!(model7, foo, :Short; first=late_start)
-connect_param!(model7, :Short=>:par, :Long=>:var)
-set_param!(model7, :Long, :par, years)
+model6 = Model()
+set_dimension!(model6, :time, years)
+add_comp!(model6, foo, :Long)
+add_comp!(model6, foo, :Short; first=late_start)
+connect_param!(model6, :Short=>:par, :Long=>:var)
+set_param!(model6, :Long, :par, years)
 
-run(model7)
+run(model6)
 
-@test length(components(model7.mi)) == 2
+@test length(components(model6.mi)) == 2
 
-short_par = model7[:Short, :par]
-short_var = model7[:Short, :var]
+short_par = model6[:Short, :par]
+short_var = model6[:Short, :var]
 
 @test short_par == years    # The parameter has values instead of `missing` for years when this component doesn't run, 
                             # because they are coming from the longer component that did run

--- a/test/test_connectorcomp.jl
+++ b/test/test_connectorcomp.jl
@@ -112,7 +112,8 @@ x = model2[:Long, :x]
     x[dim[late_start]:end] == 
     [2 * i for i in 1:(years[end]-late_start + 1)]
 
-
+@test Mimi.datum_size(model2.md, Mimi.compdef(model2.md, :Long), :x) == (length(years),)
+ 
 #------------------------------------------------------------------------------
 #  3. Test with a short component that ends early (and test Variable timesteps)
 #------------------------------------------------------------------------------
@@ -256,6 +257,8 @@ set_param!(model6, :Short, :a, 2)
 
 # A. test wrong size (needs to be length of component, not length of model)
 @test_throws ErrorException connect_param!(model6, :Long=>:x, :Short=>:b, zeros(length(years)))
+@test_throws ErrorException connect_param!(model5, :Long_multi=>:x, :Short_multi=>:b, zeros(length(years), length(regions)+1)) # test case with >1 dimension
+
 
 # B. test no backup data provided
 @test_throws ErrorException connect_param!(model6, :Long=>:x, :Short=>:b)   # Error because no backup data provided

--- a/test/test_connectorcomp.jl
+++ b/test/test_connectorcomp.jl
@@ -1,5 +1,4 @@
 module TestConnectorComp
-# @testset "ConnectorComp" begin
 
 using Mimi
 using Test
@@ -237,5 +236,5 @@ x = model5[:Long, :x]
     x[dim[first]:dim[last], :] == 
     [[i + 1 for i in 1:(years[end]-late_start + 1)] [i + 2 for i in 1:(years[end]-late_start + 1)]]
 
-# end  # testset
+
 end #module

--- a/test/test_connectorcomp.jl
+++ b/test/test_connectorcomp.jl
@@ -1,4 +1,5 @@
 module TestConnectorComp
+# @testset "ConnectorComp" begin
 
 using Mimi
 using Test
@@ -8,22 +9,8 @@ import Mimi:
 
 reset_compdefs()
 
-#
-# Test the pre-defined connector component
-#
-
-#--------------------------------------
-#  Manual way of using ConnectorComp
-#--------------------------------------
-
 @defcomp LongComponent begin
     x = Parameter(index=[time])
-    y = Parameter()
-    z = Variable(index=[time])
-    
-    function run_timestep(p, v, d, t)
-        v.z[t] = p.x[t] + p.y
-    end
 end
 
 @defcomp ShortComponent begin
@@ -35,106 +22,138 @@ end
     end
 end
 
-m = Model()
-set_dimension!(m, :time, 2000:3000)
-nsteps = Mimi.dim_count(m.md, :time)
+years = 2000:2010
+late_start = 2005
 
-add_comp!(m, ShortComponent; first=2100)
+#------------------------------------------------------------------------------
+#  1. Manual way of using ConnectorComp
+#------------------------------------------------------------------------------
+
+m = Model()
+set_dimension!(m, :time, years)
+
+add_comp!(m, ShortComponent; first=late_start)
 add_comp!(m, Mimi.ConnectorCompVector, :MyConnector) # Rename component in this model
-add_comp!(m, LongComponent; first=2000)
+add_comp!(m, LongComponent)
 
 comp_def = compdef(m, :MyConnector)
 @test Mimi.compname(comp_def.comp_id) == :ConnectorCompVector
 
 set_param!(m, :ShortComponent, :a, 2.)
-set_param!(m, :LongComponent, :y, 1.)
 connect_param!(m, :MyConnector, :input1, :ShortComponent, :b)
 
-set_param!(m, :MyConnector, :input2, zeros(nsteps))
+set_param!(m, :MyConnector, :input2, zeros(length(years)))
 connect_param!(m, :LongComponent, :x, :MyConnector, :output)
 
 run(m)
 
 b = m[:ShortComponent, :b]
 input1 = m[:MyConnector, :input1]
+output = m[:MyConnector, :output]
+x = m[:LongComponent, :x]
 
-# TBD: unclear whether this is an error. Using shorter time (later start)
-# results in an array of the same size as the original, but padded with NaNs.
-# This is because we allocate based on the length of the time dimension,
-# ignoring the start period.
+# Test that all allocated datum arrays are the full length of the time dimension
+@test length(b) == length(years)
+@test length(input1) == length(years)
+@test length(output) == length(years)
+@test length(x) == length(years)
 
-@test length(b) == 1001
-@test all(isnan, b[902:end])
+dim = Mimi.Dimension(years)
 
-@test length(input1) == 1001
-@test all(isnan, input1[902:end])
+# Test the values are the right values before the late start
+@test all(ismissing, b[1:dim[late_start]-1])
+@test all(ismissing, input1[1:dim[late_start]-1])
+@test all(iszero, output[1:dim[late_start]-1])
+@test all(iszero, x[1:dim[late_start]-1])
 
-@test length(m[:MyConnector, :input2]) ==  1001 # TBD: was 100 -- accidental deletion or...?
-@test length(m[:LongComponent, :z]) == 1001
+# Test the values are right after the late start
+@test b[dim[late_start]:end] == 
+    input1[dim[late_start]:end] == 
+    output[dim[late_start]:end] == 
+    x[dim[late_start]:end] == 
+    [2 * i for i in 1:(years[end]-late_start + 1)]
 
-@test all([m[:ShortComponent, :b][i] == 2*i for i in 1:900])
-
+# Test the dataframe size
 b = getdataframe(m, :ShortComponent, :b)
-@test size(b) == (1001, 2)
+@test size(b) == (length(years), 2)
 
-#-------------------------------------
-#  Now using new API for connecting
-#-------------------------------------
+
+#------------------------------------------------------------------------------
+#  2. Use the connect_param! method with backup data (ConnectorComp gets added 
+#       under the hood during build)
+#------------------------------------------------------------------------------
 
 model2 = Model()
-set_dimension!(model2, :time, 2000:2010)
-add_comp!(model2, ShortComponent; first=2005)
+set_dimension!(model2, :time, years)
+add_comp!(model2, ShortComponent; first=late_start)
 add_comp!(model2, LongComponent)
-
 set_param!(model2, :ShortComponent, :a, 2.)
-set_param!(model2, :LongComponent, :y, 1.)
-connect_param!(model2, :LongComponent, :x, :ShortComponent, :b, zeros(11))
+connect_param!(model2, :LongComponent, :x, :ShortComponent, :b, zeros(length(years)))
 
 run(model2)
 
-@test length(model2[:ShortComponent, :b]) == 6
-@test length(model2[:LongComponent, :z]) == 11
-@test length(components(model2.mi)) == 2
+# @test length(components(model2.mi)) == 2
+@test length(components(model2.mi)) == 3    # is there a way to prevent this? ConnectorComp is added to the list of components in the model isntance
+@test length(model2.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-#-------------------------------------
-#  A Short component that ends early
-#-------------------------------------
+b = model2[:ShortComponent, :b]
+x = model2[:LongComponent, :x]
+
+# Test that all allocated datum arrays are the full length of the time dimension
+@test length(b) == length(years)
+@test length(x) == length(years)
+
+@test all(ismissing, b[1:dim[late_start]-1])
+@test all(iszero, x[1:dim[late_start]-1])
+
+# Test the values are right after the late start
+@test b[dim[late_start]:end] == 
+    x[dim[late_start]:end] == 
+    [2 * i for i in 1:(years[end]-late_start + 1)]
+
+
+#------------------------------------------------------------------------------
+#  3. Test with a short component that ends early
+#------------------------------------------------------------------------------
+
+early_last = 2005
 
 model3 = Model()
-set_dimension!(model3, :time, 2000:2010)
-add_comp!(model3, ShortComponent; last=2005)
+set_dimension!(model3, :time, years)
+add_comp!(model3, ShortComponent; last=early_last)
 add_comp!(model3, LongComponent)
-
 set_param!(model3, :ShortComponent, :a, 2.)
-set_param!(model3, :LongComponent, :y, 1.)
-connect_param!(model3, :LongComponent, :x, :ShortComponent, :b, zeros(11))
+connect_param!(model3, :LongComponent, :x, :ShortComponent, :b, zeros(length(years)))
 
 run(model3)
 
-@test length(model3[:ShortComponent, :b]) == 6
-@test length(model3[:LongComponent, :z]) == 11
-@test length(components(model3.mi)) == 2
+@test length(components(model3.mi)) == 3    
+@test length(model3.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b2 = getdataframe(model3, :ShortComponent, :b)
-@test size(b2) == (11,2)
-@test all([b2[:b][i] == 2*i for i in 1:6])
-@test all([isnan(b2[:b][i]) for i in 7:11])
+b = model3[:ShortComponent, :b]
+x = model3[:LongComponent, :x]
 
-#------------------------------------------------------
-#  A model that requires multiregional ConnectorComps
-#------------------------------------------------------
+# Test that all allocated datum arrays are the full length of the time dimension
+@test length(b) == length(years)
+@test length(x) == length(years)
+
+@test all(ismissing, b[dim[early_last]+1 : end])
+@test all(iszero, x[dim[early_last]+1 : end])
+
+# Test the values are right after the late start
+@test b[1 : dim[early_last]] == 
+    x[1 : dim[early_last]] == 
+    [2 * i for i in 1:dim[early_last]]
+
+
+#------------------------------------------------------------------------------
+#  4. A model that requires multiregional ConnectorComps
+#------------------------------------------------------------------------------
 
 @defcomp Long begin
     regions = Index()
 
     x = Parameter(index = [time, regions])
-    out = Variable(index = [time, regions])
-    
-    function run_timestep(p, v, d, ts)
-        for r in d.regions
-            v.out[ts, r] = p.x[ts, r]
-        end
-    end
 end
 
 @defcomp Short begin
@@ -150,55 +169,73 @@ end
     end
 end
 
-model4 = Model()
-set_dimension!(model4, :time, 2000:5:2100)
-set_dimension!(model4, :regions, [:A, :B, :C])
-add_comp!(model4, Short; first=2020)
-add_comp!(model4, Long)
+regions = [:A, :B]
 
-set_param!(model4, :Short, :a, [1,2,3])
-connect_param!(model4, :Long, :x, :Short, :b, zeros(21,3))
+model4 = Model()
+set_dimension!(model4, :time, years)
+set_dimension!(model4, :regions, regions)
+add_comp!(model4, Short; first=late_start)
+add_comp!(model4, Long)
+set_param!(model4, :Short, :a, [1,2])
+connect_param!(model4, :Long, :x, :Short, :b, zeros(length(years), length(regions)))
 
 run(model4)
 
-@test size(model4[:Short, :b]) == (17, 3)
-@test size(model4[:Long, :out]) == (21, 3)
-@test length(components(model4)) == 2
+@test length(components(model4.mi)) == 3    
+@test length(model4.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b3 = getdataframe(model4, :Short, :b)
-@test size(b3)==(63,3)
+b = model4[:Short, :b]
+x = model4[:Long, :x]
 
-#-------------------------------------------------------------
-#  Test where the short component starts late and ends early
-#-------------------------------------------------------------
+# Test that all allocated datum arrays are the full length of the time dimension
+@test size(b) == (length(years), length(regions))
+@test size(x) == (length(years), length(regions))
+
+@test all(ismissing, b[1:dim[late_start]-1, :])
+@test all(iszero, x[1:dim[late_start]-1, :])
+
+# Test the values are right after the late start
+@test b[dim[late_start]:end, :] == 
+    x[dim[late_start]:end, :] == 
+    [[i + 1 for i in 1:(years[end]-late_start + 1)] [i + 2 for i in 1:(years[end]-late_start + 1)]]
+
+
+#------------------------------------------------------------------------------
+#  5. Test where the short component starts late and ends early
+#------------------------------------------------------------------------------
+
+first, last = 2002, 2007
 
 model5 = Model()
-set_dimension!(model5, :time, 2000:5:2100)
-set_dimension!(model5, :regions, [:A, :B, :C])
-add_comp!(model5, Short; first=2020, last=2070)
+set_dimension!(model5, :time, years)
+set_dimension!(model5, :regions, regions)
+add_comp!(model5, Short; first=first, last=last)
 add_comp!(model5, Long)
 
-set_param!(model5, :Short, :a, [1,2,3])
-connect_param!(model5, :Long=>:x, :Short=>:b, zeros(21,3))
+set_param!(model5, :Short, :a, [1,2])
+connect_param!(model5, :Long=>:x, :Short=>:b, zeros(length(years), length(regions)))
 
 run(model5)
 
-@test size(model5[:Short, :b]) == (11, 3)
-@test size(model5[:Long, :out]) == (21, 3)
-@test length(components(model5)) == 2
+@test length(components(model5.mi)) == 3    
+@test length(model5.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b4 = getdataframe(model5, :Short, :b)
-@test size(b4)==(63,3)
+b = model5[:Short, :b]
+x = model5[:Long, :x]
 
-#-----------------------------------------
-#  Test getdataframe with multiple pairs
-#-----------------------------------------
+# Test that all allocated datum arrays are the full length of the time dimension
+@test size(b) == (length(years), length(regions))
+@test size(x) == (length(years), length(regions))
 
-result = getdataframe(model5, :Short=>:b, :Long=>:out)
-@test size(result)==(63,4)
-[(@test isnan(result[i, :b])) for i in 1:12]
-[(@test isnan(result[i, :b])) for i in 46:63]
-[(@test result[i, :out]==0) for i in 1:12]
-[(@test result[i, :out]==0) for i in 46:63]
+@test all(ismissing, b[1:dim[first]-1, :])
+@test all(ismissing, b[dim[last]+1:end, :])
+@test all(iszero, x[1:dim[first]-1, :])
+@test all(iszero, x[dim[last]+1:end, :])
 
+# Test the values are right after the late start
+@test b[dim[first]:dim[last], :] == 
+    x[dim[first]:dim[last], :] == 
+    [[i + 1 for i in 1:(years[end]-late_start + 1)] [i + 2 for i in 1:(years[end]-late_start + 1)]]
+
+# end  # testset
 end #module

--- a/test/test_connectorcomp.jl
+++ b/test/test_connectorcomp.jl
@@ -8,11 +8,11 @@ import Mimi:
 
 reset_compdefs()
 
-@defcomp LongComponent begin
+@defcomp Long begin
     x = Parameter(index=[time])
 end
 
-@defcomp ShortComponent begin
+@defcomp Short begin
     a = Parameter()
     b = Variable(index=[time])
     
@@ -23,6 +23,7 @@ end
 
 years = 2000:2010
 late_start = 2005
+dim = Mimi.Dimension(years)
 
 #------------------------------------------------------------------------------
 #  1. Manual way of using ConnectorComp
@@ -31,33 +32,31 @@ late_start = 2005
 m = Model()
 set_dimension!(m, :time, years)
 
-add_comp!(m, ShortComponent; first=late_start)
+add_comp!(m, Short; first=late_start)
 add_comp!(m, Mimi.ConnectorCompVector, :MyConnector) # Rename component in this model
-add_comp!(m, LongComponent)
+add_comp!(m, Long)
 
 comp_def = compdef(m, :MyConnector)
 @test Mimi.compname(comp_def.comp_id) == :ConnectorCompVector
 
-set_param!(m, :ShortComponent, :a, 2.)
-connect_param!(m, :MyConnector, :input1, :ShortComponent, :b)
+set_param!(m, :Short, :a, 2.)
+connect_param!(m, :MyConnector, :input1, :Short, :b)
 
 set_param!(m, :MyConnector, :input2, zeros(length(years)))
-connect_param!(m, :LongComponent, :x, :MyConnector, :output)
+connect_param!(m, :Long, :x, :MyConnector, :output)
 
 run(m)
 
-b = m[:ShortComponent, :b]
+b = m[:Short, :b]
 input1 = m[:MyConnector, :input1]
 output = m[:MyConnector, :output]
-x = m[:LongComponent, :x]
+x = m[:Long, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
 @test length(b) == length(years)
 @test length(input1) == length(years)
 @test length(output) == length(years)
 @test length(x) == length(years)
-
-dim = Mimi.Dimension(years)
 
 # Test the values are the right values before the late start
 @test all(ismissing, b[1:dim[late_start]-1])
@@ -73,7 +72,7 @@ dim = Mimi.Dimension(years)
     [2 * i for i in 1:(years[end]-late_start + 1)]
 
 # Test the dataframe size
-b = getdataframe(m, :ShortComponent, :b)
+b = getdataframe(m, :Short, :b)
 @test size(b) == (length(years), 2)
 
 
@@ -84,10 +83,10 @@ b = getdataframe(m, :ShortComponent, :b)
 
 model2 = Model()
 set_dimension!(model2, :time, years)
-add_comp!(model2, ShortComponent; first=late_start)
-add_comp!(model2, LongComponent)
-set_param!(model2, :ShortComponent, :a, 2.)
-connect_param!(model2, :LongComponent, :x, :ShortComponent, :b, zeros(length(years)))
+add_comp!(model2, Short; first=late_start)
+add_comp!(model2, Long)
+set_param!(model2, :Short, :a, 2.)
+connect_param!(model2, :Long, :x, :Short, :b, zeros(length(years)))
 
 run(model2)
 
@@ -95,8 +94,8 @@ run(model2)
 @test length(components(model2.mi)) == 3    # is there a way to prevent this? ConnectorComp is added to the list of components in the model isntance
 @test length(model2.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b = model2[:ShortComponent, :b]
-x = model2[:LongComponent, :x]
+b = model2[:Short, :b]
+x = model2[:Long, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
 @test length(b) == length(years)
@@ -112,50 +111,53 @@ x = model2[:LongComponent, :x]
 
 
 #------------------------------------------------------------------------------
-#  3. Test with a short component that ends early
+#  3. Test with a short component that ends early (and test Variable timesteps)
 #------------------------------------------------------------------------------
 
-early_last = 2005
+years_variable = [2000:2004..., 2005:5:2030...]
+dim_variable = Mimi.Dimension(years_variable)
+
+early_last = 2010
 
 model3 = Model()
-set_dimension!(model3, :time, years)
-add_comp!(model3, ShortComponent; last=early_last)
-add_comp!(model3, LongComponent)
-set_param!(model3, :ShortComponent, :a, 2.)
-connect_param!(model3, :LongComponent, :x, :ShortComponent, :b, zeros(length(years)))
+set_dimension!(model3, :time, years_variable)
+add_comp!(model3, Short; last=early_last)
+add_comp!(model3, Long)
+set_param!(model3, :Short, :a, 2.)
+connect_param!(model3, :Long, :x, :Short, :b, zeros(length(years_variable)))
 
 run(model3)
 
 @test length(components(model3.mi)) == 3    
 @test length(model3.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b = model3[:ShortComponent, :b]
-x = model3[:LongComponent, :x]
+b = model3[:Short, :b]
+x = model3[:Long, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
-@test length(b) == length(years)
-@test length(x) == length(years)
+@test length(b) == length(years_variable)
+@test length(x) == length(years_variable)
 
-@test all(ismissing, b[dim[early_last]+1 : end])
-@test all(iszero, x[dim[early_last]+1 : end])
+@test all(ismissing, b[dim_variable[early_last]+1 : end])
+@test all(iszero, x[dim_variable[early_last]+1 : end])
 
 # Test the values are right after the late start
-@test b[1 : dim[early_last]] == 
-    x[1 : dim[early_last]] == 
-    [2 * i for i in 1:dim[early_last]]
+@test b[1 : dim_variable[early_last]] == 
+    x[1 : dim_variable[early_last]] == 
+    [2 * i for i in 1:dim_variable[early_last]]
 
 
 #------------------------------------------------------------------------------
 #  4. A model that requires multiregional ConnectorComps
 #------------------------------------------------------------------------------
 
-@defcomp Long begin
+@defcomp Long_multi begin
     regions = Index()
 
     x = Parameter(index = [time, regions])
 end
 
-@defcomp Short begin
+@defcomp Short_multi begin
     regions = Index()
 
     a = Parameter(index=[regions])
@@ -173,18 +175,18 @@ regions = [:A, :B]
 model4 = Model()
 set_dimension!(model4, :time, years)
 set_dimension!(model4, :regions, regions)
-add_comp!(model4, Short; first=late_start)
-add_comp!(model4, Long)
-set_param!(model4, :Short, :a, [1,2])
-connect_param!(model4, :Long, :x, :Short, :b, zeros(length(years), length(regions)))
+add_comp!(model4, Short_multi; first=late_start)
+add_comp!(model4, Long_multi)
+set_param!(model4, :Short_multi, :a, [1,2])
+connect_param!(model4, :Long_multi, :x, :Short_multi, :b, zeros(length(years), length(regions)))
 
 run(model4)
 
 @test length(components(model4.mi)) == 3    
 @test length(model4.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b = model4[:Short, :b]
-x = model4[:Long, :x]
+b = model4[:Short_multi, :b]
+x = model4[:Long_multi, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
 @test size(b) == (length(years), length(regions))
@@ -208,19 +210,19 @@ first, last = 2002, 2007
 model5 = Model()
 set_dimension!(model5, :time, years)
 set_dimension!(model5, :regions, regions)
-add_comp!(model5, Short; first=first, last=last)
-add_comp!(model5, Long)
+add_comp!(model5, Short_multi; first=first, last=last)
+add_comp!(model5, Long_multi)
 
-set_param!(model5, :Short, :a, [1,2])
-connect_param!(model5, :Long=>:x, :Short=>:b, zeros(length(years), length(regions)))
+set_param!(model5, :Short_multi, :a, [1,2])
+connect_param!(model5, :Long_multi=>:x, :Short_multi=>:b, zeros(length(years), length(regions)))
 
 run(model5)
 
 @test length(components(model5.mi)) == 3    
 @test length(model5.md.comp_defs) == 2      # The ConnectorComp shows up in the model instance but not the model definition
 
-b = model5[:Short, :b]
-x = model5[:Long, :x]
+b = model5[:Short_multi, :b]
+x = model5[:Long_multi, :x]
 
 # Test that all allocated datum arrays are the full length of the time dimension
 @test size(b) == (length(years), length(regions))
@@ -235,6 +237,72 @@ x = model5[:Long, :x]
 @test b[dim[first]:dim[last], :] == 
     x[dim[first]:dim[last], :] == 
     [[i + 1 for i in 1:(years[end]-late_start + 1)] [i + 2 for i in 1:(years[end]-late_start + 1)]]
+
+
+#------------------------------------------------------------------------------
+#  6. Test errors with backup data
+#------------------------------------------------------------------------------
+
+late_start_long = 2002
+
+model6 = Model()
+set_dimension!(model6, :time, years)
+add_comp!(model6, Short; first = late_start)
+add_comp!(model6, Long; first = late_start_long)    # starts later as well, so backup data needs to match this size
+set_param!(model6, :Short, :a, 2)
+
+# A. test wrong size (needs to be length of component, not length of model)
+@test_throws ErrorException connect_param!(model6, :Long=>:x, :Short=>:b, zeros(length(years)))
+
+# B. test no backup data provided
+# TODO: do we want this to error?
+connect_param!(model6, :Long=>:x, :Short=>:b)   # Connect long to short without any backup
+
+run(model6)     # TODO: doesn't error, is that okay?
+
+@test length(components(model6.mi)) == 2    # no ConnectorComp added because no backup data given  
+@test length(model6.md.comp_defs) == 2      
+
+b = model6[:Short, :b]
+x = model6[:Long, :x]
+
+@test all(ismissing, b[1:dim[late_start]-1])
+@test all(ismissing, x[1:dim[late_start]-1])    # Values are `missing` in Long's :x parameter because no backup data
+
+
+#------------------------------------------------------------------------------
+#  7. Test connecting Short component to Long component (does not add a 
+#       connector component)
+#------------------------------------------------------------------------------
+
+@defcomp foo begin
+    par = Parameter(index=[time])
+    var = Variable(index=[time])
+    function run_timestep(p, v, d, ts)
+        v.var[ts] = p.par[ts]
+    end
+end
+
+model7 = Model()
+set_dimension!(model7, :time, years)
+add_comp!(model7, foo, :Long)
+add_comp!(model7, foo, :Short; first=late_start)
+connect_param!(model7, :Short=>:par, :Long=>:var)
+set_param!(model7, :Long, :par, years)
+
+run(model7)
+
+@test length(components(model7.mi)) == 2
+
+short_par = model7[:Short, :par]
+short_var = model7[:Short, :var]
+
+@test short_par == years    # TODO: is this the functionality we want? it has values instead of 
+                            # `missing`` for years when this component doesn't run, because they are 
+                            # coming from the longer component that did run
+
+@test all(ismissing, short_var[1:dim[late_start]-1])
+@test short_var[dim[late_start]:end] == years[dim[late_start]:end]
 
 
 end #module

--- a/test/test_datum_storage.jl
+++ b/test/test_datum_storage.jl
@@ -72,4 +72,52 @@ for (i, y) in enumerate(years)
 end
 
 
+#------------------------------------------------------------------------------
+# 3. Single dimension case, variable timesteps
+#------------------------------------------------------------------------------
+
+years_variable = [2000:2004..., 2005:5:2030...]
+last = 2010
+
+m = Model()
+set_dimension!(m, :time, years_variable)
+add_comp!(m, foo, first=comp_first, last=last)
+
+run(m)
+v = m[:foo, :v]
+@test length(v) == length(years_variable) # Test that the array allocated for variable v is the full length of the time dimension
+
+# Test that the missing values were filled in before/after the first/last values
+for (i, y) in enumerate(years_variable)
+    if y < comp_first || y > last
+        @test ismissing(v[i])
+    else
+        @test v[i] == y
+    end
+end
+
+#------------------------------------------------------------------------------
+# 4. Multi-dimension case, variable timesteps
+#------------------------------------------------------------------------------
+
+m2 = Model()
+
+set_dimension!(m2, :time, years_variable)
+set_dimension!(m2, :region, regions)
+add_comp!(m2, bar, first=comp_first, last=last)
+
+run(m2)
+v2 = m2[:bar, :v]
+@test size(v2) == (length(years_variable), length(regions)) # Test that the array allocated for variable v is the full length of the time dimension
+
+# Test that the missing values were filled in before/after the first/last values
+for (i, y) in enumerate(years_variable)
+    if y < comp_first || y > last
+        [@test ismissing(v2[i, j]) for j in 1:length(regions)]
+    else
+        [@test v2[i, j]==y for j in 1:length(regions)]
+    end
+end
+
+
 end # module

--- a/test/test_datum_storage.jl
+++ b/test/test_datum_storage.jl
@@ -1,0 +1,75 @@
+module TestDatumStorage
+
+using Mimi
+using Test
+
+@defcomp foo begin
+    v = Variable(index = [time])
+    function run_timestep(p, v, d, ts)
+        v.v[ts] = gettime(ts)
+    end
+end
+
+@defcomp bar begin
+    region = Index()
+    v = Variable(index = [time, region])
+    function run_timestep(p, v, d, ts)
+        # v.v[ts, 1:end] = gettime(ts)
+        for d in d.region
+            v.v[ts, d] = gettime(ts)
+        end
+    end
+end
+
+years = 2001:2010
+regions = [:A, :B]
+comp_first = 2003
+comp_last = 2008
+
+
+#------------------------------------------------------------------------------
+# 1. Single dimension case, fixed timesteps
+#------------------------------------------------------------------------------
+
+m = Model()
+set_dimension!(m, :time, years)
+add_comp!(m, foo, first=comp_first, last=comp_last)
+
+run(m)
+v = m[:foo, :v]
+@test length(v) == length(years) # Test that the array allocated for variable v is the full length of the time dimension
+
+# Test that the missing values were filled in before/after the first/last values
+for (i, y) in enumerate(years)
+    if y < comp_first || y > comp_last
+        @test ismissing(v[i])
+    else
+        @test v[i] == y
+    end
+end
+
+#------------------------------------------------------------------------------
+# 2. Multi-dimension case, fixed timesteps
+#------------------------------------------------------------------------------
+
+m2 = Model()
+
+set_dimension!(m2, :time, years)
+set_dimension!(m2, :region, regions)
+add_comp!(m2, bar, first=comp_first, last=comp_last)
+
+run(m2)
+v2 = m2[:bar, :v]
+@test size(v2) == (length(years), length(regions)) # Test that the array allocated for variable v is the full length of the time dimension
+
+# Test that the missing values were filled in before/after the first/last values
+for (i, y) in enumerate(years)
+    if y < comp_first || y > comp_last
+        [@test ismissing(v2[i, j]) for j in 1:length(regions)]
+    else
+        [@test v2[i, j]==y for j in 1:length(regions)]
+    end
+end
+
+
+end # module

--- a/test/test_getdataframe.jl
+++ b/test/test_getdataframe.jl
@@ -8,11 +8,11 @@ import Mimi:
 
 reset_compdefs()
 
-#
-# Test with > 2 dimensions
-#
+#------------------------------------------------------------------------------
+#   1. Test with 1 dimension
+#------------------------------------------------------------------------------
 
-my_model = Model()
+model1 = Model()
 
 @defcomp testcomp1 begin
     var1 = Variable(index=[time])
@@ -33,73 +33,97 @@ end
     end
 end
 
-@defcomp testcomp3 begin
-    var3 = Variable(index=[time])
-    par3 = Parameter(index=[time])
-    function run_timestep(p, v, d, t)
-        v.var3[t] = p.par3[t]
-    end
-end
+years = collect(2015:5:2110)
+late_first = 2030
+early_last = 2100
 
-par = collect(2015:5:2110)
+set_dimension!(model1, :time, years)
+add_comp!(model1, testcomp1)
+set_param!(model1, :testcomp1, :par1, years)
+set_param!(model1, :testcomp1, :par_scalar, 5.)
+add_comp!(model1, testcomp2; first = late_first, last = early_last)
+set_param!(model1, :testcomp2, :par2, late_first:5:early_last)
 
-set_dimension!(my_model, :time, 2015:5:2110)
-add_comp!(my_model, testcomp1)
-set_param!(my_model, :testcomp1, :par1, par)
-set_param!(my_model, :testcomp1, :par_scalar, 5.)
 
 # Test running before model built
-@test_throws ErrorException dataframe = getdataframe(my_model, :testcomp1, :var1)
+@test_throws ErrorException df = getdataframe(model1, :testcomp1, :var1)
 
 # Now run model
-run(my_model)
+run(model1)
+
+# Test trying to load a dataframe for a scalar parameter
+@test_throws ErrorException getdataframe(model1, :testcomp1, :par_scalar)
+
+# Test trying to getdataframe from a variable that does not exist in the component
+@test_throws ErrorException getdataframe(model1, :testcomp1, :var2)
 
 # Regular getdataframe
-dataframe = getdataframe(my_model, :testcomp1, :var1)
-@test(dataframe[2] == par)
-
-# Test trying to getdataframe from component that does not exist
-@test_throws ErrorException getdataframe(my_model, :testcomp1, :var2)
+df = getdataframe(model1, :testcomp1=>:var1, :testcomp1=>:par1, :testcomp2=>:var2, :testcomp2=>:par2)
+dim = Mimi.dimension(model1, :time)
+@test df[:var1] == df[:par1] == years
+@test all(ismissing, df[:var2][1 : dim[late_first]-1])
+@test all(ismissing, df[:par2][1 : dim[late_first]-1])
+@test df[:var2][dim[late_first] : dim[early_last]] == df[:par2][dim[late_first] : dim[early_last]] == late_first:5:early_last
+@test all(ismissing, df[:var2][dim[years[end]] : dim[early_last]])
+@test all(ismissing, df[:par2][dim[years[end]] : dim[early_last]])
 
 # Test trying to load an item into an existing dataframe where that item key already exists
-@test_throws ErrorException _load_dataframe(my_model, :testcomp1, :var1, dataframe)
+@test_throws ErrorException _load_dataframe(model1, :testcomp1, :var1, df)
 
-# Test trying to load a dataframe for a scalar
-@test_throws ErrorException _load_dataframe(my_model, :testcomp1, :par_scalar, dataframe)
 
-#
-# Test with > 2 dimensions
-#
-new_model = Model()
+#------------------------------------------------------------------------------
+#   2. Test with > 2 dimensions
+#------------------------------------------------------------------------------
 
-@defcomp testcomp4 begin
-    par1 = Parameter(index=[time, regions, rates])
+@defcomp testcomp3 begin
+    par3 = Parameter(index=[time, regions, rates])
     var3 = Variable(index=[time])
-    
-    function run_timestep(p, v, d, t)
-    end
 end
 
-years   = 2015:5:2020
 regions = [:reg1, :reg2]
 rates   = [0.025, 0.05]
 
-set_dimension!(new_model, :time, years)
-set_dimension!(new_model, :regions, regions)
-set_dimension!(new_model, :rates, rates)
+# A. Simple case where component has same time length as model
+
+model2 = Model()
+
+set_dimension!(model2, :time, years)
+set_dimension!(model2, :regions, regions)
+set_dimension!(model2, :rates, rates)
 
 data = Array{Int}(undef, length(years), length(regions), length(rates))
 data[:] = 1:(length(years) * length(regions) * length(rates))
 
-add_comp!(new_model, testcomp4)
-set_param!(new_model, :testcomp4, :par1, data)
+add_comp!(model2, testcomp3)
+set_param!(model2, :testcomp3, :par3, data)
 
-run(new_model)
+run(model2)
 
-df = getdataframe(new_model, :testcomp4, :par1)
-@test size(df) == (8, 4)
+df2 = getdataframe(model2, :testcomp3, :par3)
+@test size(df2) == (length(data), 4)
 
 # Test trying to combine two items with different dimensions into one dataframe
-@test_throws ErrorException getdataframe(new_model, Pair(:testcomp4, :par1), Pair(:testcomp4, :var3))
+@test_throws ErrorException getdataframe(model2, Pair(:testcomp3, :par3), Pair(:testcomp3, :var3))
+
+
+# B. Test with shorter time than model 
+
+model3 = Model()
+set_dimension!(model3, :time, years)
+set_dimension!(model3, :regions, regions)
+set_dimension!(model3, :rates, rates)
+add_comp!(model3, testcomp3; first = late_first, last = early_last)
+
+par3 = Array{Float64}(undef, length(late_first:5:early_last), length(regions), length(rates))
+par3[:] = 1:(length(late_first:5:early_last) * length(regions) * length(rates))
+set_param!(model3, :testcomp3, :par3, par3)
+run(model3)
+
+df3 = getdataframe(model3, :testcomp3=>:par3)
+@test size(df3) == (length(rates)*length(regions)*length(years), 4)
+
+# Test that times outside the component's time span are padded with `missing` values
+@test all(ismissing, df3[:par3][1 : (length(rates)*length(regions)*(dim[late_first]-1))])
+@test all(ismissing, df3[:par3][end - (length(rates)*length(regions)*(dim[end]-dim[early_last]))+1: end])
 
 end #module

--- a/test/test_model_structure_variabletimestep.jl
+++ b/test/test_model_structure_variabletimestep.jl
@@ -42,14 +42,18 @@ end
     end
 end
 
-m = Model()
 years = [2015:5:2100; 2110:10:2200]
+first_A = 2050
+last_A = 2150
+
+m = Model()
 set_dimension!(m, :time, years)
 
 @test_throws ErrorException add_comp!(m, A, last = 2210) 
 @test_throws ErrorException add_comp!(m, A, first = 2010) 
 @test_throws ArgumentError add_comp!(m, A, after=:B)
-add_comp!(m, A, first = 2050, last = 2150) #test specific last and first
+# @test_throws ErrorException add_comp!(m, A, after=:B)
+add_comp!(m, A, first = first_A, last = last_A) #test specific last and first
 
 add_comp!(m, B, before=:A)
 
@@ -84,9 +88,13 @@ connect_param!(m, :C => :parC, :B => :varB)
 
 run(m)
 
-@test all([m[:A, :varA][t] == 1 for t in 1:2])
-@test all([m[:A, :varA][t] == 10 for t in 3:16])
+# @test all([m[:A, :varA][t] == 1 for t in 1:2])
+# @test all([m[:A, :varA][t] == 10 for t in 3:16])
 
+dim = Mimi.Dimension(years)
+varA = m[:A, :varA][dim[first_A]:dim[last_A]]
+@test all([varA[i] == 1 for i in 1:2])
+@test all([varA[i] == 10 for i in 3:16])
 
 ##########################
 #   tests for indexing   #

--- a/test/test_plotting.jl
+++ b/test/test_plotting.jl
@@ -27,29 +27,16 @@ end
     end
 end
 
-@defcomp ConnectorComponent begin
-    input1 = Parameter(index = [time])
-    input2 = Parameter(index = [time])
-    output =  Variable(index = [time])
-
-    function run_timestep(p, v, d, ts)
-        v.output[ts] = p.input2[ts]
-    end
-end
-
 m = Model()
 set_dimension!(m, :time, 2000:3000)
 nsteps = Mimi.dim_count(m.md, :time)
 
 add_comp!(m, ShortComponent; first=2100)
-add_comp!(m, ConnectorComponent)
 add_comp!(m, LongComponent; first=2000)
 
 set_param!(m, :ShortComponent, :a, 2.)
 set_param!(m, :LongComponent, :y, 1.)
-connect_param!(m, :ConnectorComponent, :input1, :ShortComponent, :b)
-set_param!(m, :ConnectorComponent, :input2, zeros(nsteps))
-connect_param!(m, :LongComponent, :x, :ConnectorComponent, :output)
+connect_param!(m, :LongComponent, :x, :ShortComponent, :b, zeros(nsteps))
 
 run(m)
 

--- a/test/test_timesteps.jl
+++ b/test/test_timesteps.jl
@@ -10,9 +10,9 @@ import Mimi:
 
 reset_compdefs()
 
-########################################################################
-#  Test basic timestep functions and Base functions for Fixed Timestep #
-########################################################################
+#------------------------------------------------------------------------------
+#  Test basic timestep functions and Base functions for Fixed Timestep 
+#------------------------------------------------------------------------------
 
 t1 = FixedTimestep{1850, 10, 3000}(1)
 @test is_first(t1)
@@ -33,9 +33,10 @@ t4 = next_timestep(t3)
 @test_throws ErrorException t_next = t4 + 1
 @test_throws ErrorException next_timestep(t4)
 
-###########################################################################
-#  Test basic timestep functions and Base functions for Variable Timestep #
-###########################################################################
+
+#------------------------------------------------------------------------------
+#  Test basic timestep functions and Base functions for Variable Timestep 
+#------------------------------------------------------------------------------
 years = Tuple([2000:1:2024; 2025:5:2105])
 
 t1 = VariableTimestep{years}()
@@ -58,9 +59,10 @@ t4 = next_timestep(t3)
 @test_throws ErrorException t_next = t4 + 1
 @test_throws ErrorException next_timestep(t4)
 
-#########################################################
-#  Test a model with components with different offsets  #
-#########################################################
+
+#------------------------------------------------------------------------------
+#  Test a model with components with different offsets  
+#------------------------------------------------------------------------------
 
 # we'll have Bar run from 2000 to 2010
 # and Foo from 2005 to 2010
@@ -122,9 +124,10 @@ for i in 6:11
     @test m[:Bar, :output][i] == i*i
 end
 
-##################################################
+#------------------------------------------------------------------------------
 #  test get_timestep_array
-##################################################
+#------------------------------------------------------------------------------
+
 m = Model()
 
 #fixed timestep to start
@@ -152,9 +155,10 @@ t_matrix = get_timestep_array(m.md, Float64, 2, matrix)
 @test typeof(t_vector) <: TimestepVector
 @test typeof(t_matrix) <: TimestepMatrix
 
-##################################################
-#  Now build a model with connecting components  #
-##################################################
+
+#------------------------------------------------------------------------------
+#  Now build a model with connecting components  
+#------------------------------------------------------------------------------
 
 @defcomp Foo2 begin
     inputF = Parameter(index=[time])
@@ -183,31 +187,29 @@ for i in 1:6
     @test foo_output2[i] == (i+5)^2
 end
 
-#########################################
-#  Connect them in the other direction  #
-#########################################
+#------------------------------------------------------------------------------
+#  Connect them in the other direction  
+#------------------------------------------------------------------------------
 
 @defcomp Bar2 begin
     inputB = Parameter(index=[time])
     output = Variable(index=[time])
     
     function run_timestep(p, v, d, ts)
-        if gettime(ts) < 2005
-            v.output[ts] = 0
-        else
-            v.output[ts] = p.inputB[ts] * ts.t
-        end
+        v.output[ts] = p.inputB[ts] * ts.t
     end
 end
 
+years = 2000:2010
+
 m3 = Model()
 
-set_dimension!(m3, :time, 2000:2010)
+set_dimension!(m3, :time, years)
 add_comp!(m3, Foo, first=2005)
 add_comp!(m3, Bar2)
 
 set_param!(m3, :Foo, :inputF, 5.)
-connect_param!(m3, :Bar2, :inputB, :Foo, :output)
+connect_param!(m3, :Bar2, :inputB, :Foo, :output, zeros(length(years)))
 run(m3)
 
 @test length(m3[:Foo, :output]) == 11


### PR DESCRIPTION
This changes the array allocation for datum in components whose time dimensions are shorter than the model's time dimension. Now, TimestepArrays are allocated for the full length of the model's time index, and any cells before or after the component's first or last timestep values are padded with `missing` values. Addresses issue #321 

To do/questions:

- [x] Need to make final decision on if we pad with `missing`, `nothing`, or `NaN`
- [x] Do we want `getdataframe` to use `missing` or `nothing` instead of NaNs as well?
- [ ] I made a new test file "test_datum_storage.jl" to explicitly show the stuff we just changed, but these could probably get deleted or moved into the "test_connectorcomp.jl" test file. They are redundant, but they explicitly show the functionality, so not sure if we should keep them or not
- [x]  If backup data (during connections between shorter and longer components) has more than one dimension, only the size of the time dimension is checked against its size. Should we check other dimensions as well? How do we do this if the other dimensions aren't named/aren't necessarily in the same order as the model's dimensions?
- [x] should the provided backup data be required to be the full length of the model's time index, or just the full length of the longer component that it's filling in for?
- [x] When the `connect_param!` function is used with backup data, a ConnectorComp is added under the hood during build. This component does not show up in the model definition's list of components, but it shows up in the model instance's list of components. Is that okay?
- [ ] should I delete the `_vars_NT_type` function in "build.jl" that seems to be deprecated? (it's not called anywhere)
- [x] need to add tests for variable timesteparrays (to increase diff coverage)
- [x] need to add tests for error case (backup data wrong size)