### PR TITLE
Add is_timestep and is_time functions

### DIFF
--- a/docs/src/integrationguide.md
+++ b/docs/src/integrationguide.md
@@ -90,13 +90,13 @@ As previously mentioned, some relevant function names have changed.  These chang
 |`isstart`                  |`is_first`                 |
 |`isstop`                   |`is_last`                  |    
 
-As mentioned in earlier in this document, the fourth argument in `run_timestep` is an `AbstractTimestep` i.e. a `FixedTimestep` or a `VariableTimestep` and is a type defined within Mimi in "src/time.jl".  In this version, the fourth argument (`t` below) can no longer always be used simply as an `Int`. Defining the `AbstractTimestep` object as `t`, indexing with `t` is still permitted, but special care must be taken when comparing `t` with conditionals or using it in arithmatic expressions.  Since differential equations are commonly used as the basis for these models' equations, the most commonly needed change will be changing `if t == 1` to `if is_first(t)`
+As mentioned in earlier in this document, the fourth argument in `run_timestep` is an `AbstractTimestep` i.e. a `FixedTimestep` or a `VariableTimestep` and is a type defined within Mimi in "src/time.jl".  In this version, the fourth argument (`t` below) can no longer always be used simply as an `Int`. Defining the `AbstractTimestep` object as `t`, indexing with `t` is still permitted, but special care must be taken when comparing `t` with conditionals or using it in arithmatic expressions.  Since differential equations are commonly used as the basis for these models' equations, the most commonly needed change will be changing `if t == 1` to `if is_first(t)`.  There are also new useful functions including `is_time(t, y)` and `is_timestep(t, s)`.
 
 The full API:
 
 - you may index into a variable or parameter with `[t]` or `[t +/- x]` as usual
 - to access the time value of `t` (currently a year) as a `Number`, use `gettime(t)`
-- useful functions for commonly used conditionals are `is_first(t)`,`is_last(t)`, as listed above
+- useful functions for commonly used conditionals are `is_first(t)`,`is_last(t)`, `is_time(t, y)`, and `is_timestep(t, s)`as listed above
 - to access the index value of `t` as a `Number` representing the position in the time array, use `t.t`.  Users are encouraged to avoid this access, and instead use the options listed above or a separate counter variable. each time the function gets called.  
 
 ### Parameter connections between different length components

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -18,6 +18,8 @@ get_var_value
 hasvalue
 is_first
 is_last
+is_time
+is_timestep
 load_comps
 modeldef
 name

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -180,13 +180,15 @@ In the run_timestep functions which the user defines, it may be useful to use an
 is_first(t) # returns true or false, true if t is the first timestep to be run
 is_last(t) # returns true or false, true if t is the last timestep to be run
 gettime(t) # returns the year represented by timestep t
+is_time(t, s) # Return true or false, true if the current time (year) for t is y
+is_timestep(t, y) # rReturn true or false, true if t timestep is step s.
 ```
 
 The API details for AbstractTimestep object `t` are as follows:
 
 - you may index into a variable or parameter with `[t]` or `[t +/- x]` as usual
 - to access the time value of `t` (currently a year) as a `Number`, use `gettime(t)`
-- useful functions for commonly used conditionals are `is_first(t)`,`is_last(t)`, as listed above
+- useful functions for commonly used conditionals are `is_first(t)`,`is_last(t)`, `is_time(t, s)`, and `is_timestep(t, y)` as listed above
 - to access the index value of `t` as a `Number` representing the position in the time array, use `t.t`.  Users are encouraged to avoid this access, and instead use the options listed above or a separate counter variable. each time the function gets called. 
 
 ### Parameter connections between different length components

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -25,6 +25,8 @@ export
     hasvalue,
     is_first,
     is_last,
+    is_time,
+    is_timestep,
     load_comps,
     modeldef,
     name,

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -25,7 +25,7 @@ end
 
 Return true or false, true if the current time (year) for `ts` is `t`
 """
-function istime(ts::AbstractTimestep, t::Int) 
+function is_time(ts::AbstractTimestep, t::Int) 
 	return gettime(ts) == t
 end
 
@@ -39,9 +39,9 @@ function is_first(ts::AbstractTimestep)
 end
 
 """
-	is_timestep(ts::AbstractTimestep)
+	is_timestep(ts::AbstractTimestep, t::Int)
 
-Return true or false, true if `ts` timestep `t`.
+Return true or false, true if `ts` timestep is step `t`.
 """
 function is_timestep(ts::AbstractTimestep, t::Int)
 	return ts.t == t

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -21,12 +21,30 @@ function gettime(ts::VariableTimestep)
 end
 
 """
+	is_time(ts::AbstractTimestep, t::Int)
+
+Return true or false, true if the current time (year) for `ts` is `t`
+"""
+function istime(ts::AbstractTimestep, t::Int) 
+	return gettime(ts) == t
+end
+
+"""
 	is_first(ts::AbstractTimestep)
 
 Return true or false, true if `ts` is the first timestep to be run.
 """
 function is_first(ts::AbstractTimestep)
 	return ts.t == 1
+end
+
+"""
+	is_timestep(ts::AbstractTimestep)
+
+Return true or false, true if `ts` timestep `t`.
+"""
+function is_timestep(ts::AbstractTimestep, t::Int)
+	return ts.t == t
 end
 
 """

--- a/test/test_timesteps.jl
+++ b/test/test_timesteps.jl
@@ -6,7 +6,8 @@ using Test
 import Mimi:
     AbstractTimestep, FixedTimestep, VariableTimestep, TimestepVector, 
     TimestepMatrix, TimestepArray, next_timestep, hasvalue, is_first, is_last, 
-    gettime, getproperty, Clock, time_index, get_timestep_array, reset_compdefs
+    gettime, getproperty, Clock, time_index, get_timestep_array, reset_compdefs, 
+    is_timestep, is_time
 
 reset_compdefs()
 
@@ -16,10 +17,14 @@ reset_compdefs()
 
 t1 = FixedTimestep{1850, 10, 3000}(1)
 @test is_first(t1)
+@test is_timestep(t1, 1)
+@test is_time(t1, 1850)
 @test_throws ErrorException t1_prev = t1-1 #first timestep, so cannot get previous
 
 t2 = next_timestep(t1)
 @test t2.t == 2
+@test is_timestep(t2, 2)
+@test is_time(t2, 1860)
 @test_throws ErrorException t2_prev = t2 - 2 #can't get before first timestep
 
 @test t2 == t1 + 1
@@ -30,6 +35,8 @@ t3 = FixedTimestep{2000, 1, 2050}(51)
 @test_throws ErrorException t3_next = t3 + 2 #can't go beyond last timestep
 
 t4 = next_timestep(t3)
+@test is_timestep(t4, 52)
+@test is_time(t4, 2051)
 @test_throws ErrorException t_next = t4 + 1
 @test_throws ErrorException next_timestep(t4)
 
@@ -40,10 +47,14 @@ years = Tuple([2000:1:2024; 2025:5:2105])
 
 t1 = VariableTimestep{years}()
 @test is_first(t1)
+@test is_timestep(t1, 1)
+@test is_time(t1, 2000)
 @test_throws ErrorException t1_prev = t1-1 #first timestep, so cannot get previous
 
 t2 = next_timestep(t1)
 @test t2.t == 2
+@test is_timestep(t2, 2)
+@test is_time(t2,2001)
 @test_throws ErrorException t2_prev = t2 - 2 #can't get before first timestep
 
 @test t2 == t1 + 1
@@ -55,6 +66,8 @@ t3 = VariableTimestep{years}(42)
 @test_throws ErrorException t3_next = t3 + 2 #can't go beyond last timestep
 
 t4 = next_timestep(t3)
+@test is_timestep(t4, 43)
+@test is_time(t4, 2106) #note here that this comes back to an assumption made in variable timesteps that we may assume the next step is 1 year
 @test_throws ErrorException t_next = t4 + 1
 @test_throws ErrorException next_timestep(t4)
 


### PR DESCRIPTION
- [x] add functions `is_time` and `is_timestep`
- [x] add tests for these functions
- [x] add documentation

@rjplevin  @ckingdon95 Note that if `t` is your last timestep i.e. `is_last(t) == true`, and `t_next = next_timestep(t)`, the time associated with `t_next` will always be `gettime(t) + 1`, *even for variable timesteps* where preceding steps might have been greater than 1.  This was an assumption we decided to make when dealing with how to deal with the final step, and I still think it holds well here, but wanted to mention it.  We really shouldn't be calling `is_time` on that `t_next` ... but I think it's fine as it is.  One idea would be to throw a warning if we do that, but could that check could add overhead.