### PR TITLE
Cap Documenter to v0.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ script:
 after_success:
   - julia -e 'using Pkg; cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'using Pkg; cd(Pkg.dir("Mimi")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
-  - julia -e 'using Pkg; Pkg.add("Documenter")'
+  - julia -e 'using Pkg; ps=PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps)'
   - julia -e 'using Pkg; ENV["DOCUMENTER_DEBUG"]=true; cd(Pkg.dir("Mimi")); include(joinpath("docs","make.jl"))'


### PR DESCRIPTION
Due to upcoming breaking changes in Documenter. This makes sure that the doc builds do not start failing when 0.20 lands in METADATA. [See this thread on Discourse for more information.](https://discourse.julialang.org/t/psa-documenter-jl-breaking-changes-version-capping/16431) 

Ref: JuliaDocs/Documenter.jl#861