### PR TITLE
ON HOLD Add docs and errors to enforce naming of dims (patch for v0.5.1)

### DIFF
--- a/docs/src/integrationguide.md
+++ b/docs/src/integrationguide.md
@@ -97,6 +97,24 @@ The full API:
 ### Parameter connections between different length components
 
 ### More on parameter indices
+The ability to set a parameter with the syntax below is temporarily not available.  It will be reinstated soon.  Users should now replaces this notation with an explicit dimension name, as shown below.   
+
+ ```julia
+ @defcomp MyComponent begin
+   p1 = Parameter(index=[4]) # an array of length 4
+ end
+ ```
+ should be changed to 
+
+ ```julia
+ @defcomp MyComponent begin
+   p1 = Parameter(index=[dim]) # an array of length 4
+ end
+ ```
+ and then set using 
+ ```julia
+ set_dimension!(m, :dim, 1:4)
+ ```
 
 ### Updating an external parameter
 

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -204,15 +204,14 @@ Note: for now, to avoid discrepancy with timing and alignment, the backup data m
 
 ### More on parameter indices
 
-As mentioned above, a parameter can have no index (a scalar), or one or multiple of the model's indexes. A parameter can also have an index specified in the following ways:
+As mentioned above, a parameter can have no index (a scalar), or one or multiple of the model's indexes. A parameter can also have an index specified in the following way:
 
 ```julia
 @defcomp MyComponent begin
-  p1 = Parameter(index=[4]) # an array of length 4
-  p2::Array{Float64, 2} = Parameter() # a two dimensional array of unspecified length
+  p1:Array{Float64, 2} = Parameter() # a two dimensional array of unspecified length
 end
 ```
-In both of these cases, the parameter's values are stored of as an array (p1 is one dimensional, and p2 is two dimensional). But with respect to the model, they are considered "scalar" parameters, simply because they do not use any of the model's indices (namely 'time', or 'regions').
+In this case, the parameter's values are stored of as an array (p1 is two dimensional). But with respect to the model, it is considered a "scalar" parameter, simply because it does not use any of the model's indices (namely 'time', or 'regions')
 
 ### Updating an external parameter
 

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -242,7 +242,7 @@ macro defcomp(comp_name, ex)
 
                 elseif @capture(arg, index = [dims__])
                     debug("    dims: $dims")
-                    if !isempty(filter(x -> !(x isa String), dims))
+                    if !isempty(filter(x -> !(x isa Symbol), dims))
                         error("dimensions must be defined by a Symbol placeholder")
                     end
                     append!(dimensions, dims)

--- a/src/core/defcomp.jl
+++ b/src/core/defcomp.jl
@@ -242,6 +242,9 @@ macro defcomp(comp_name, ex)
 
                 elseif @capture(arg, index = [dims__])
                     debug("    dims: $dims")
+                    if !isempty(filter(x -> !(x isa String), dims))
+                        error("dimensions must be defined by a Symbol placeholder")
+                    end
                     append!(dimensions, dims)
 
                     # Add undeclared dimensions on-the-fly


### PR DESCRIPTION
This PR adds a small patch for `v0.5.2` to add documentation and an error that gives some clarity on the currently non-functional state of anonymous dimension naming.  TBD on whether we decide to make this patch or not.