### PR TITLE
Anonymous dimensions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -13,6 +13,7 @@ FileIO
 GraphPlot 0.3.0
 JSON
 LightGraphs
+Logging
 MacroTools
 MetaGraphs
 NamedArrays

--- a/src/core/build.jl
+++ b/src/core/build.jl
@@ -56,18 +56,6 @@ function _instantiate_datum(md::ModelDef, def::DatumDef)
     return value
 end
 
-# Deprecated?
-# function _vars_NT_type(md::ModelDef, comp_def::ComponentDef)
-#     var_defs = variables(comp_def)    
-#     vnames = Tuple([name(vdef) for vdef in var_defs])
-    
-#     first = comp_def.first
-#     vtypes = Tuple{[_instance_datatype(md, vdef, first) for vdef in var_defs]...}
-
-#     NT = NamedTuple{vnames, vtypes}
-#     return NT
-# end
-
 """
     _instantiate_component_vars(md::ModelDef, comp_def::ComponentDef)
 

--- a/src/core/defs.jl
+++ b/src/core/defs.jl
@@ -53,8 +53,7 @@ end
 """
     name(def::NamedDef) = def.name 
 
-Return the name of `def`.  Possible `NamedDef`s include `DatumDef`, `ComponentDef`, 
-and `DimensionDef`.
+Return the name of `def`.  Possible `NamedDef`s include `DatumDef`, and `ComponentDef`.
 """
 name(def::NamedDef) = def.name
 
@@ -118,14 +117,24 @@ end
 #
 # Dimensions
 #
+"""
+    add_dimension!(comp::ComponentDef, name)
+
+Add a dimension name to a `ComponentDef`, with an optional Dimension definition.
+The definition is included only for the case of anonymous dimensions, which are 
+indicated in `@defcomp` with an Int rather than a symbol name. In this case, the
+Int (e.g., 4) is converted to a dimension of the same length, e.g., `Dimension(4)`,
+and assigned a new name `Symbol(4)``
+"""
 function add_dimension!(comp::ComponentDef, name)
-    comp.dimensions[name] = dim_def = DimensionDef(name)
-    return dim_def
+    # create the Dimension and store it in the ComponentDef until build time
+    dim = (name isa Int) ? Dimension(name) : nothing
+    comp.dimensions[Symbol(name)] = dim
 end
 
 add_dimension!(comp_id::ComponentId, name) = add_dimension!(compdef(comp_id), name)
 
-dimensions(comp_def::ComponentDef) = values(comp_def.dimensions)
+dimensions(comp_def::ComponentDef) = keys(comp_def.dimensions)
 
 dimensions(def::DatumDef) = def.dimensions
 

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -200,16 +200,12 @@ mutable struct DatumDef <: NamedDef
 
 end
 
-mutable struct DimensionDef <: NamedDef
-    name::Symbol
-end
-
 mutable struct ComponentDef  <: NamedDef
     name::Symbol
     comp_id::ComponentId
     variables::OrderedDict{Symbol, DatumDef}
     parameters::OrderedDict{Symbol, DatumDef}
-    dimensions::OrderedDict{Symbol, DimensionDef}
+    dimensions::OrderedDict{Symbol, Union{Nothing, Dimension}}
     first::Union{Nothing, Int}
     last::Union{Nothing, Int}
 
@@ -221,7 +217,7 @@ mutable struct ComponentDef  <: NamedDef
         self.comp_id = comp_id
         self.variables  = OrderedDict{Symbol, DatumDef}()
         self.parameters = OrderedDict{Symbol, DatumDef}() 
-        self.dimensions = OrderedDict{Symbol, DimensionDef}()
+        self.dimensions = OrderedDict{Symbol, Union{Nothing, Dimension}}()
         self.first = self.last = nothing
         return self
     end

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -1,3 +1,14 @@
+using Logging
+
+# Enable @debug logging
+function set_log_level(level)
+    global_logger(ConsoleLogger(stderr, level))
+end
+
+log_debug() = set_log_level(Logging.Debug)
+log_info()  = set_log_level(Logging.Info)
+
+
 """
     interpolate(values, ts=10)
 

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -72,7 +72,7 @@ add_comp!(my_model, testcomp3)
 
 comps = compdefs(my_model)
 
-#Test compdefs, compdef, compkeys, etc.
+# Test compdefs, compdef, compkeys, etc.
 @test comps == compdefs(my_model.md)
 @test length(comps) == 3
 @test compdef(:testcomp3) == [comps...][3]
@@ -87,15 +87,7 @@ comps = compdefs(my_model)
 add_comp!(my_model, testcomp3, :testcomp3_v2)
 @test numcomponents(my_model) == 4
 
-#Test some component dimensions fcns, other dimensions testing in test_dimensions
-def = compdef(:testcomp3)
-def_dims = dimensions(def)
-@test eltype(def_dims) == Mimi.DimensionDef && length(def_dims) == 1
-@test [def_dims...][1].name == :time
-
-# dump_components() #view all components and their info
-
-#Test reset_compdefs methods
+#T est reset_compdefs methods
 reset_compdefs()
 @test length(_compdefs) == 3 #adder, ConnectorCompVector, ConnectorCompMatrix
 reset_compdefs(false)

--- a/test/test_components.jl
+++ b/test/test_components.jl
@@ -5,8 +5,8 @@ using Test
 
 import Mimi:
     reset_compdefs, compdefs, compdef, compkeys, hascomp, _compdefs, first_period, 
-    last_period, compmodule, compname, numcomponents, dump_components, 
-    dimensions
+    last_period, compmodule, compname, numcomponents, dump_components,  
+    dim_keys, dim_values, dimensions
 
 reset_compdefs()
 
@@ -41,6 +41,7 @@ end
 @defcomp testcomp3 begin
     var1 = Variable(index=[time])
     par1 = Parameter(index=[time])
+    cbox = Variable(index=[time, 5])    # anonymous dimension
     
     function run_timestep(p, v, d, t)
         v.var1[t] = p.par1[t]
@@ -66,16 +67,21 @@ add_comp!(my_model, testcomp1)
 # N.B. Throws ArgumentError in v1.0, but ErrorException in 0.7!
 @test_throws ArgumentError add_comp!(my_model, testcomp2, after=:testcomp3)
 
-#Add more components to model
+# Add more components to model
 add_comp!(my_model, testcomp2)
 add_comp!(my_model, testcomp3)
 
-comps = compdefs(my_model)
+# Check addition of anonymous dimension
+dvals = dim_values(my_model.md, Symbol(5))
+dkeys = dim_keys(my_model.md, Symbol(5))
+@test dvals == dkeys
+
+comps = collect(compdefs(my_model))
 
 # Test compdefs, compdef, compkeys, etc.
-@test comps == compdefs(my_model.md)
+@test comps == collect(compdefs(my_model.md))
 @test length(comps) == 3
-@test compdef(:testcomp3) == [comps...][3]
+@test compdef(:testcomp3) == comps[3]
 @test_throws ErrorException compdef(:testcomp4) #this component does not exist
 @test [compkeys(my_model.md)...] == [:testcomp1, :testcomp2, :testcomp3]
 @test hascomp(my_model.md, :testcomp1) == true && hascomp(my_model.md, :testcomp4) == false
@@ -87,9 +93,9 @@ comps = compdefs(my_model)
 add_comp!(my_model, testcomp3, :testcomp3_v2)
 @test numcomponents(my_model) == 4
 
-#T est reset_compdefs methods
+# Test reset_compdefs methods
 reset_compdefs()
-@test length(_compdefs) == 3 #adder, ConnectorCompVector, ConnectorCompMatrix
+@test length(_compdefs) == 3 # adder, ConnectorCompVector, ConnectorCompMatrix
 reset_compdefs(false)
 @test length(_compdefs) == 0 
 

--- a/test/test_dimensions.jl
+++ b/test/test_dimensions.jl
@@ -86,7 +86,11 @@ end
 
 # Test resetting the time dimension
 
-@defcomp foo2 begin x = Parameter(index=[time]) end 
+@defcomp foo2 begin 
+    x = Parameter(index=[time]) 
+    y = Variable(index=[4])
+end 
+
 m = Model()
 set_dimension!(m, :time, 2000:2100)
 @test_throws ErrorException add_comp!(m, foo2; first = 2005, last = 2105)   # Can't add a component longer than a model


### PR DESCRIPTION
I've restored support for dimensions given simply as an integer, and all the tests pass, but I haven't tested it on a "real" model that uses this feature. 

@lrennels, would you be willing to test this on the model that illuminated the problem? If that works, and all other tests pass, I think we're good to go. (DONE, works on fund)