### PR TITLE
Support `missing` backup data

### DIFF
--- a/src/components/connector.jl
+++ b/src/components/connector.jl
@@ -15,15 +15,8 @@ using Mimi
             input = p.input2
         end 
 
-        try 
-            v.output[ts] = input[ts]
-        catch e
-            if e isa MissingException
-                v.output[ts] = missing
-            else
-                rethrow([e])
-            end
-        end
+        v.output[ts] = @allow_missing(input[ts])
+        
     end
 end
 
@@ -46,15 +39,7 @@ end
         end 
 
         for r in d.regions
-            try 
-                v.output[ts, r] = input[ts, r]
-            catch e
-                if e isa MissingException
-                    v.output[ts, r] = missing
-                else
-                    rethrow([e])
-                end
-            end
+            v.output[ts, r] = @allow_missing(input[ts, r])
         end
     end
 end

--- a/src/components/connector.jl
+++ b/src/components/connector.jl
@@ -10,10 +10,20 @@ using Mimi
 
     function run_timestep(p, v, d, ts)
         if gettime(ts) >= p.first && gettime(ts) <= p.last
-            v.output[ts.t] = p.input1[ts.t]
+            input = p.input1
         else
-            v.output[ts.t] = p.input2[ts.t]
+            input = p.input2
         end 
+
+        try 
+            v.output[ts] = input[ts]
+        catch e
+            if e isa MissingException
+                v.output[ts] = missing
+            else
+                rethrow([e])
+            end
+        end
     end
 end
 
@@ -28,10 +38,23 @@ end
     last = Parameter()  # last year to use the shorter data
 
     function run_timestep(p, v, d, ts)
-        if gettime(ts) >= p.first && gettime(ts) <= p.last 
-            v.output[ts.t, :] = p.input1[ts.t, :]
+
+        if gettime(ts) >= p.first && gettime(ts) <= p.last
+            input = p.input1
         else
-            v.output[ts.t, :] = p.input2[ts.t, :]
+            input = p.input2
+        end 
+
+        for r in d.regions
+            try 
+                v.output[ts, r] = input[ts, r]
+            catch e
+                if e isa MissingException
+                    v.output[ts, r] = missing
+                else
+                    rethrow([e])
+                end
+            end
         end
     end
 end

--- a/src/components/connector.jl
+++ b/src/components/connector.jl
@@ -10,9 +10,9 @@ using Mimi
 
     function run_timestep(p, v, d, ts)
         if gettime(ts) >= p.first && gettime(ts) <= p.last
-            v.output[ts] = p.input1[ts]
+            v.output[ts.t] = p.input1[ts.t]
         else
-            v.output[ts] = p.input2[ts]
+            v.output[ts.t] = p.input2[ts.t]
         end 
     end
 end
@@ -29,9 +29,9 @@ end
 
     function run_timestep(p, v, d, ts)
         if gettime(ts) >= p.first && gettime(ts) <= p.last 
-            v.output[ts, :] = p.input1[ts, :]
+            v.output[ts.t, :] = p.input1[ts.t, :]
         else
-            v.output[ts, :] = p.input2[ts, :]
+            v.output[ts.t, :] = p.input2[ts.t, :]
         end
     end
 end

--- a/src/core/connections.jl
+++ b/src/core/connections.jl
@@ -125,7 +125,7 @@ function connect_param!(md::ModelDef,
         dst_param = parameter(dst_comp_def, dst_par_name)
         dst_dims  = dimensions(dst_param)
 
-        backup = convert(Array{number_type(md)}, backup) # converts number type and, if it's a NamedArray, it's converted to Array
+        backup = convert(Array{Union{Missing, number_type(md)}}, backup) # converts number type and, if it's a NamedArray, it's converted to Array
         first = first_period(md, dst_comp_def)
         T = eltype(backup)        
         

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -180,10 +180,6 @@ const AnyIndex = Union{Int, Vector{Int}, Tuple, Colon, OrdinalRange}
 # TBD: can it be reduced to this?
 # const AnyIndex = Union{Int, AbstractRange}
 
-#
-# 3b. TimestepVector
-#
-
 # Helper function for getindex; throws a MissingException if data is missing, otherwise returns data
 function _missing_data_check(data)
 	if data === missing
@@ -192,6 +188,28 @@ function _missing_data_check(data)
 		return data
 	end
 end 
+
+# Helper macro used by connector 
+macro allow_missing(expr)
+	let e = gensym("e")
+		retexpr = :(
+			try
+				return $expr
+			catch $e
+				if $e isa MissingException
+					return missing 
+				else
+					rethrow($e)
+				end
+			end
+		)
+		return esc(retexpr)
+	end
+end
+
+#
+# 3b. TimestepVector
+#
 
 function Base.getindex(v::TimestepVector{FixedTimestep{FIRST, STEP}, T}, ts::FixedTimestep{FIRST, STEP, LAST}) where {T, FIRST, STEP, LAST} 
 	data = v.data[ts.t]

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -192,17 +192,17 @@ end
 # Helper macro used by connector 
 macro allow_missing(expr)
 	let e = gensym("e")
-		retexpr = :(
+		retexpr = quote
 			try
-				return $expr
+				$expr
 			catch $e
 				if $e isa MissingException
-					return missing 
+					missing 
 				else
 					rethrow($e)
 				end
 			end
-		)
+		end
 		return esc(retexpr)
 	end
 end

--- a/src/core/time.jl
+++ b/src/core/time.jl
@@ -184,42 +184,35 @@ const AnyIndex = Union{Int, Vector{Int}, Tuple, Colon, OrdinalRange}
 # 3b. TimestepVector
 #
 
-function Base.getindex(v::TimestepVector{FixedTimestep{FIRST, STEP}, T}, ts::FixedTimestep{FIRST, STEP, LAST}) where {T, FIRST, STEP, LAST} 
-	data = v.data[ts.t]
+# Helper function for getindex; throws a MissingException if data is missing, otherwise returns data
+function _missing_data_check(data)
 	if data === missing
-		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
+		throw(MissingException("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed."))
 	else
 		return data
 	end
+end 
+
+function Base.getindex(v::TimestepVector{FixedTimestep{FIRST, STEP}, T}, ts::FixedTimestep{FIRST, STEP, LAST}) where {T, FIRST, STEP, LAST} 
+	data = v.data[ts.t]
+	_missing_data_check(data)
 end
 
 function Base.getindex(v::TimestepVector{VariableTimestep{TIMES}, T}, ts::VariableTimestep{TIMES}) where {T, TIMES}
 	data = v.data[ts.t]
-	if data === missing
-		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
-	else
-		return data
-	end
+	_missing_data_check(data)
 end
 
 function Base.getindex(v::TimestepVector{FixedTimestep{D_FIRST, STEP}, T}, ts::FixedTimestep{T_FIRST, STEP, LAST}) where {T, D_FIRST, T_FIRST, STEP, LAST} 
 	t = Int(ts.t + (T_FIRST - D_FIRST) / STEP)
 	data = v.data[t]
-	if data === missing
-		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
-	else
-		return data
-	end
+	_missing_data_check(data)
 end
 
 function Base.getindex(v::TimestepVector{VariableTimestep{D_FIRST}, T}, ts::VariableTimestep{T_FIRST}) where {T, D_FIRST, T_FIRST}
 	t = ts.t + findfirst(isequal(T_FIRST[1]), D_FIRST) - 1
 	data = v.data[t]
-	if data === missing
-		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
-	else
-		return data
-	end
+	_missing_data_check(data)
 end
 
 # int indexing version supports old-style components and internal functions, not
@@ -274,40 +267,24 @@ Base.lastindex(v::TimestepVector) = length(v)
 
 function Base.getindex(mat::TimestepMatrix{FixedTimestep{FIRST, STEP}, T}, ts::FixedTimestep{FIRST, STEP, LAST}, i::AnyIndex) where {T, FIRST, STEP, LAST} 
 	data = mat.data[ts.t, i]
-	if data === missing
-		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
-	else
-		return data
-	end
+	_missing_data_check(data)
 end
 
 function Base.getindex(mat::TimestepMatrix{VariableTimestep{TIMES}, T}, ts::VariableTimestep{TIMES}, i::AnyIndex) where {T, TIMES}
 	data = mat.data[ts.t, i]
-	if data === missing
-		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
-	else
-		return data
-	end
+	_missing_data_check(data)
 end
 
 function Base.getindex(mat::TimestepMatrix{FixedTimestep{D_FIRST, STEP}, T}, ts::FixedTimestep{T_FIRST, STEP, LAST}, i::AnyIndex) where {T, D_FIRST, T_FIRST, STEP, LAST} 
 	t = Int(ts.t + (T_FIRST - D_FIRST) / STEP)
 	data = mat.data[t, i]
-	if data === missing
-		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
-	else
-		return data
-	end
+	_missing_data_check(data)
 end
 
 function Base.getindex(mat::TimestepMatrix{VariableTimestep{D_FIRST}, T}, ts::VariableTimestep{T_FIRST}, i::AnyIndex) where {T, D_FIRST, T_FIRST}
 	t = ts.t + findfirst(isequal(T_FIRST[1]), D_FIRST) - 1
 	data = mat.data[t, i]
-	if data === missing
-		error("Cannot get index; data is missing. You may have tried to access a value that has not yet been computed.")
-	else
-		return data
-	end
+	_missing_data_check(data)
 end
 
 # int indexing version supports old-style components and internal functions, not

--- a/test/test_timesteparrays.jl
+++ b/test/test_timesteparrays.jl
@@ -243,7 +243,7 @@ add_comp!(m, foo, :second)
 connect_param!(m, :second=>:par, :first=>:var)
 set_param!(m, :first, :par, 1:length(years))
 
-@test_throws ErrorException run(m)
+@test_throws MissingException run(m)
 
 
 end #module


### PR DESCRIPTION
- Allows for backup data to contain `missing` values by adding the Union{Missing, T} type where the array is instantiated
- Allows ConnectorComps to access missing values and pass them through