### PR TITLE
WIP Fix dependency paths

### DIFF
--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -10,7 +10,7 @@ end
 
 #list of URLs of branches of packages to test
 dependencies = [
-    "https://github.com/ckingdon95/fund/archive/9bf61c315b52685128bf1ae40179e245e12d8213",
+    "https://github.com/ckingdon95/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993",
     "https://github.com/anthofflab/mimi-rice-2010.jl/archive/2b5996b0a0c8be92290991f045c43af425c5a9c8.zip"
 ]
 

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -10,8 +10,8 @@ end
 
 #list of URLs of branches of packages to test
 dependencies = [
-    "https://github.com/lrennels/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993.zip",
-    "https://github.com/lrennels/mimi-rice-2010.jl/archive/2b5996b0a0c8be92290991f045c43af425c5a9c8.zip"
+    "https://github.com/ckingdon95/fund/archive/9bf61c315b52685128bf1ae40179e245e12d8213",
+    "https://github.com/anthofflab/mimi-rice-2010.jl/archive/2b5996b0a0c8be92290991f045c43af425c5a9c8.zip"
 ]
 
 function run_dependency_tests(dependencies=dependencies)

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -10,7 +10,7 @@ end
 
 #list of URLs of branches of packages to test
 dependencies = [
-    "https://github.com/fund-model/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993",
+    "https://github.com/fund-model/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993.zip",
     "https://github.com/anthofflab/mimi-rice-2010.jl/archive/2b5996b0a0c8be92290991f045c43af425c5a9c8.zip"
 ]
 

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -10,7 +10,7 @@ end
 
 #list of URLs of branches of packages to test
 dependencies = [
-    "https://github.com/ckingdon95/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993",
+    "https://github.com/fund-model/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993",
     "https://github.com/anthofflab/mimi-rice-2010.jl/archive/2b5996b0a0c8be92290991f045c43af425c5a9c8.zip"
 ]
 


### PR DESCRIPTION

The `rice` path is fixed, the `fund` repo will fail it needs to be updated when the fund 1.0 branch is merged in