### PR TITLE
Update dependency paths

### DIFF
--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -52,11 +52,8 @@ function run_dependency_tests(dependencies=dependencies)
 
         #test the package
         try
-            println("trying to run $package_name tests")
             run(`$(Sys.BINDIR)/julia $process`)
-            println("ran $package_name tests")
         catch e
-            println("running $package_name errored immediately, appending error")
             append!(errors, [(package_name, e)])
         end
         #delete current package before testing next one (if it was a downloaded package)

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -52,8 +52,11 @@ function run_dependency_tests(dependencies=dependencies)
 
         #test the package
         try
+            println("trying to run $package_name tests")
             run(`$JULIA_HOME/julia $process`)
+            println("ran $package_name tests")
         catch e
+            println("running $package_name errored immediately, appending error")
             append!(errors, [(package_name, e)])
         end
         #delete current package before testing next one (if it was a downloaded package)

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -10,8 +10,8 @@ end
 
 #list of URLs of branches of packages to test
 dependencies = [
-    "https://github.com/lrennels/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993.zip",
-    "https://github.com/lrennels/mimi-rice-2010.jl/archive/2b5996b0a0c8be92290991f045c43af425c5a9c8.zip"
+    "https://github.com/fund-model/fund/archive/1768edf12aaaac3a41bbea081d5b51299121f993.zip",
+    "https://github.com/anthofflab/mimi-rice-2010.jl/archive/2b5996b0a0c8be92290991f045c43af425c5a9c8.zip"
 ]
 
 function run_dependency_tests(dependencies=dependencies)

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -1,5 +1,11 @@
 using Pkg
 Pkg.add("InfoZIP")
+Pkg.add("ExcelReaders")
+Pkg.add("DataFrames")
+Pkg.add("CSVFiles")
+Pkg.add("CSV")
+Pkg.add("StatsBase")
+Pkg.add("Distributions")
 
 using Mimi
 using InfoZIP

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -53,7 +53,7 @@ function run_dependency_tests(dependencies=dependencies)
         #test the package
         try
             println("trying to run $package_name tests")
-            run(`$JULIA_HOME/julia $process`)
+            run(`$(Sys.BINDIR)/julia $process`)
             println("ran $package_name tests")
         catch e
             println("running $package_name errored immediately, appending error")


### PR DESCRIPTION
Fixes #377 
- need to update `fund` path once the `1.0` branch is merged