### PR TITLE
Mcs bugfix

### DIFF
--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -492,7 +492,7 @@ function run_mcs(mcs::MonteCarloSimulation, m::Model, trials::Union{Vector{Int},
     return run_mcs(mcs, trials, models_to_run; kwargs...)
 end
 
-function run_mcs(mcs::MonteCarloSimulation, m::Model, trials=mcs.trials, 
+function run_mcs(mcs::MonteCarloSimulation, m::Model, trials::Int=mcs.trials, 
                  models_to_run::Int=length(mcs.models) + 1; kwargs...)
     set_model!(mcs, m)
     return run_mcs(mcs, 1:trials, models_to_run; kwargs...)
@@ -505,7 +505,7 @@ function run_mcs(mcs::MonteCarloSimulation, models::Vector{Model}, trials=Union{
     return run_mcs(mcs, trials, models_to_run; kwargs...)
 end
 
-function run_mcs(mcs::MonteCarloSimulation, models::Vector{Model}, trials=mcs.trials, 
+function run_mcs(mcs::MonteCarloSimulation, models::Vector{Model}, trials::Int=mcs.trials, 
                 models_to_run::Int=length(mcs.models) + length(models); kwargs...)
     set_models!(mcs, models)
     return run_mcs(mcs, 1:trials, models_to_run; kwargs...)

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -147,6 +147,8 @@ function generate_trials!(mcs::MonteCarloSimulation, trials::Int;
                           filename::String="",
                           sampling::SamplingOptions=RANDOM)
 
+    mcs.trials = trials
+	
     if sampling == LHS
         corrmatrix = correlation_matrix(mcs)
         lhs!(mcs, corrmatrix=corrmatrix)

--- a/src/mcs/montecarlo.jl
+++ b/src/mcs/montecarlo.jl
@@ -146,7 +146,6 @@ than RANDOM. (Currently, only LHS and RANDOM are possible.)
 function generate_trials!(mcs::MonteCarloSimulation, trials::Int; 
                           filename::String="",
                           sampling::SamplingOptions=RANDOM)
-    mcs.trials = trials
 
     if sampling == LHS
         corrmatrix = correlation_matrix(mcs)
@@ -486,20 +485,33 @@ function run_mcs(mcs::MonteCarloSimulation, trials::Int=mcs.trials,
     return run_mcs(mcs, 1:trials, models_to_run; kwargs...)
 end
 
-# Same as above, but takes a single model to run
-function run_mcs(mcs::MonteCarloSimulation, m::Model, trials=mcs.trials, 
-                 models_to_run::Int=length(mcs.models); kwargs...)
+# Two methods mirroring the two above, but take a single model to run
+function run_mcs(mcs::MonteCarloSimulation, m::Model, trials::Union{Vector{Int}, AbstractRange{Int}}, 
+                models_to_run::Int=length(mcs.models) + 1; kwargs...)
     set_model!(mcs, m)
     return run_mcs(mcs, trials, models_to_run; kwargs...)
 end
 
-# Same as above, but takes a multiple models to run
+function run_mcs(mcs::MonteCarloSimulation, m::Model, trials=mcs.trials, 
+                 models_to_run::Int=length(mcs.models) + 1; kwargs...)
+    set_model!(mcs, m)
+    return run_mcs(mcs, 1:trials, models_to_run; kwargs...)
+end
+
+# Two methods mirroring the two above, but take multiple models to run
+function run_mcs(mcs::MonteCarloSimulation, models::Vector{Model}, trials=Union{Vector{Int}, AbstractRange{Int}}, 
+                 models_to_run::Int=length(mcs.models) + length(models); kwargs...)
+    set_models!(mcs, models)
+    return run_mcs(mcs, trials, models_to_run; kwargs...)
+end
+
 function run_mcs(mcs::MonteCarloSimulation, models::Vector{Model}, trials=mcs.trials, 
-                 models_to_run::Int=length(mcs.models); kwargs...)
+                models_to_run::Int=length(mcs.models) + length(models); kwargs...)
     set_models!(mcs, models)
     return run_mcs(mcs, 1:trials, models_to_run; kwargs...)
 end
 
+# Set models
 function set_models!(mcs::MonteCarloSimulation, models::Vector{Model})
     mcs.models = models
     _reset_results!(mcs)    # sets results vector to same length


### PR DESCRIPTION
This PR fixes the MCS bug that did not increment `models_to_run` when a model, or vector of models, were passed to `run_mcs`.  It also augments the set of `run_mcs` methods to be comprehensive about `trials::Int` and `trials::Union{Int, Vector{Int}, AbstractRange{Int}}`.
